### PR TITLE
Make org-supertag-sim optional

### DIFF
--- a/org-supertag.el
+++ b/org-supertag.el
@@ -52,8 +52,7 @@
 (require 'org-supertag-luhmann)
 (require 'org-supertag-view)
 (require 'org-supertag-inline)
-(require 'org-supertag-sim)
-(require 'org-supertag-sim-epc) 
+(require 'org-supertag-sim nil t)
 
 (defgroup org-supertag nil
   "Customization options for org-supertag."


### PR DESCRIPTION
My laptop probably won't be able to run ollama, so I want to turn sim features off.