### PR TITLE
feat: Add field reordering functionality to node view

### DIFF
--- a/org-supertag-field.el
+++ b/org-supertag-field.el
@@ -524,13 +524,13 @@ VALUE: Value to convert."
          (tag-id (plist-get field-def :tag-id))
          (field-type (plist-get field-def :type))
          (raw-value (org-supertag-field-get-value node-id field-name tag-id)))
-    ;;(message "DEBUG: get-value node-id=%S field-name=%S field-type=%S raw-value=%S (type=%S)"
-             node-id field-name field-type raw-value (type-of raw-value))
+    ;; (message "DEBUG: get-value node-id=%S field-name=%S field-type=%S raw-value=%S (type=%S)"
+    ;;          node-id field-name field-type raw-value (type-of raw-value))
     (if (and (eq field-type 'tag) raw-value (stringp raw-value))
         (let ((result (split-string raw-value "," t)))
           ;;(message "DEBUG: get-value split result: %S" result)
           result)
-      raw-value))
+      raw-value)))
 
 
 ;;----------------------------------------------------------------------


### PR DESCRIPTION
- Add M-p/M-n key bindings for moving fields up/down in tag field lists
- Implement org-supertag-view-node-move-field-up and org-supertag-view-node-move-field-down functions
- Add org-supertag-view-node-refresh-and-restore-position for maintaining cursor position after field moves
- Fix field-type variable error in org-supertag-field-get-value-for-display by properly commenting debug code
- Fix current-type formatting in field definition editor to handle non-symbol types
- Update help text to reflect new reordering functionality
- Improve cursor positioning logic to accurately locate moved fields using text properties