### PR TITLE
fix: support forward slash path format

### DIFF
--- a/supertag-core-store.el
+++ b/supertag-core-store.el
@@ -377,23 +377,18 @@ Returns a list of (node-id . node-data) pairs."
 
 (defun supertag-find-nodes-by-file (file-path)
   "Find all nodes located in FILE-PATH.
-This version uses a single, robust pass to find nodes, normalizing
-file paths before comparison to ensure correctness.
 Returns a list of (node-id . node-data) pairs."
   (let ((nodes-collection (supertag-get '(:nodes)))
-        (found-nodes '())
-        ;; Normalize the target path once at the beginning for efficiency.
-        (normalized-query-path (expand-file-name file-path)))
+        (found-nodes '()))
     (when (hash-table-p nodes-collection)
       (maphash
        (lambda (id node-data)
          ;; Safely extract :file and ensure it's a string
          (when-let* ((node-file (and node-data (plist-get node-data :file)))
                      ((stringp node-file)))
-           ;; Normalize both paths before comparing
-           (let ((normalized-node-file (expand-file-name node-file)))
-             (when (equal normalized-node-file normalized-query-path)
-               (push (cons id node-data) found-nodes)))))
+           ;; Direct string comparison without path normalization
+           (when (equal node-file file-path)
+             (push (cons id node-data) found-nodes))))
        nodes-collection))
     (nreverse found-nodes)))
 

--- a/supertag-ops-node.el
+++ b/supertag-ops-node.el
@@ -50,14 +50,10 @@ Implements immediate error reporting as preferred by the user."
 Combines old architecture performance with new architecture safety.
 Provides strict validation with immediate error reporting."
   (let* ((id (or (plist-get props :id) (org-id-new)))
-         ;; Ensure :file property is always normalized and present
-         (file (plist-get props :file))
-         (normalized-file (when file (expand-file-name file)))
-         (props (if file (plist-put props :file normalized-file) props))
          ;; Build final props with required fields (hybrid approach)
          (final-props (plist-put props :id id))
          (final-props (plist-put final-props :type :node))
-         (final-props (plist-put final-props :created-at 
+         (final-props (plist-put final-props :created-at
                                  (or (plist-get final-props :created-at) (current-time))))
          (final-props (plist-put final-props :modified-at (current-time))))
     

--- a/supertag-services-sync.el
+++ b/supertag-services-sync.el
@@ -464,7 +464,7 @@ COUNTERS is a plist for tracking :nodes-created, :nodes-updated, and :nodes-dele
           (when (and db-node
                      (let ((db-node-file (plist-get db-node :file)))
                        (and db-node-file
-                            (string= (expand-file-name db-node-file) (expand-file-name file)))))
+                            (string= db-node-file file))))
             ;;(message "DEBUG: Marking node %s as orphaned because file %s no longer exists" id file)
             (supertag-node-mark-deleted-from-file id)
             (setf (plist-get counters :nodes-deleted) (1+ (plist-get counters :nodes-deleted))))))
@@ -486,7 +486,7 @@ COUNTERS is a plist for tracking :nodes-created, :nodes-updated, and :nodes-dele
             (when (and db-node
                        (let ((db-node-file (plist-get db-node :file)))
                          (and db-node-file
-                              (string= (expand-file-name db-node-file) (expand-file-name file)))))
+                              (string= db-node-file file))))
               ;;(message "DEBUG: Node %s deleted from file %s. Marking as orphaned." id file)
               (supertag-node-mark-deleted-from-file id)
               (setf (plist-get counters :nodes-deleted)


### PR DESCRIPTION
Remove expand-file-name path normalization code to make org-supertag-sync-directories support Unix-style forward slash path format.

Before fix: system enforced double backslash format
After fix: now supports forward slash paths like C:/Users/Jack/Desktop/org/

Example configuration:
(setq org-supertag-sync-directories '("C:/Users/Jack/Desktop/org/"))