### PR TITLE
feat: import legacy :tag: on init; add capture body input

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Once this command finishes executing, org-supertag will be ready to serve you.
 
 Failure to perform this migration will result in incompatibility with the new version and potential data loss.
 
+### 🏷️ Compatibility with legacy :tag:
+
+Org-SuperTag now reads both inline `#tag` and Org's native `:tag:` during sync/import. This preserves your existing files without modification and makes historical tags available in the database. Capture continues to create inline `#tag` in new headings; export behavior is unchanged.
+
 ## 🚀 What is Org-SuperTag?
 
 > Org-SuperTag is a revolutionary Org-mode extension that upgrades the traditional tagging system into an intelligent knowledge management engine.  

--- a/doc/CAPTURE-GUIDE.md
+++ b/doc/CAPTURE-GUIDE.md
@@ -1,5 +1,7 @@
 # Org-Supertag Capture System
 
+Note: Legacy Org `:tag:` remain readable during sync/import. New capture writes inline `#tag` as before.
+
 ## 🚀 What is the Capture System?
 
 The Org-Supertag Capture System provides a powerful and flexible node creation mechanism, supporting dynamic templates, content generators, and automatic field filling. This system follows the data separation principle, storing node content and extended properties separately in Org files and the database.

--- a/supertag-services-capture.el
+++ b/supertag-services-capture.el
@@ -337,7 +337,9 @@ If TEMPLATE-KEY is not provided, prompts for one."
                   (completing-read "Template: "
                                    (mapcar (lambda (t) (cons (car t) (cadr t))) template-alist)
                                    nil t)))
-         (template-data (cdr (assoc key template-alist)))
+         ;; Each template has shape: (KEY DESCRIPTION PLIST)
+         ;; We need the PLIST only, so drop the first two elements.
+         (template-data (cddr (assoc key template-alist)))
          (target-file (plist-get template-data :file))
          (node-spec (plist-get template-data :node-spec)))
     (unless template-data

--- a/supertag-services-capture.el
+++ b/supertag-services-capture.el
@@ -268,7 +268,7 @@ ARGS is a list containing the function symbol."
           (:fields (setq fields (supertag-capture--get-content get-spec))))))
     `(:title ,title :tags ,tags :body ,body :fields ,fields)))
 
-(defun supertag-capture--execute (target-file processed-data)
+  (defun supertag-capture--execute (target-file processed-data)
   "Execute the capture by writing data to file and syncing.
 TARGET-FILE is the path to the destination file.
 PROCESSED-DATA is the plist from --process-spec."
@@ -276,31 +276,28 @@ PROCESSED-DATA is the plist from --process-spec."
     (user-error "TARGET-FILE cannot be nil"))
   (unless (file-exists-p target-file)
     (user-error "Target file does not exist: %s" target-file))
-  (let* ((title (plist-get processed-data :title))
-         (tags (plist-get processed-data :tags))
-         (body (plist-get processed-data :body))
-         (field-settings (plist-get processed-data :fields))
-         ;; Assemble the node string
-         (tags-str (if tags (mapconcat (lambda (tag) (concat "#" tag)) tags " ") ""))
-         (full-title (if (string-empty-p tags-str) title (format "%s %s" title tags-str)))
-         ;; Get location
-         (insert-info (supertag-ui-select-insert-position target-file))
-         (insert-pos (plist-get insert-info :position))
-         (insert-level (plist-get insert-info :level)))
+    (let* ((title (plist-get processed-data :title))
+           (tags (plist-get processed-data :tags))
+           (body (plist-get processed-data :body))
+           (field-settings (plist-get processed-data :fields))
+           ;; Get location
+           (insert-info (supertag-ui-select-insert-position target-file))
+           (insert-pos (plist-get insert-info :position))
+           (insert-level (plist-get insert-info :level)))
     (unless insert-info
       (user-error "No valid insert position selected"))
 
     ;; Side Effect 1: Write to file
-    (let ((new-node-id (org-id-new)))
-      (with-current-buffer (find-file-noselect target-file)
-        (save-excursion
-          (goto-char insert-pos)
-          (unless (or (bobp) (looking-back "\n" 1)) (insert "\n"))
-          (insert (make-string insert-level ?*) " " full-title "\n")
-          (unless (string-empty-p body)
-            (insert body "\n"))
-          (insert "\n:PROPERTIES:\n:ID: " new-node-id "\n:END:\n")
-          (save-buffer)))
+      (let ((new-node-id (org-id-new)))
+        (with-current-buffer (find-file-noselect target-file)
+          (save-excursion
+            (goto-char insert-pos)
+            (unless (or (bobp) (looking-back "\n" 1)) (insert "\n"))
+            (insert (supertag--render-org-headline insert-level title tags target-file nil))
+            (unless (string-empty-p body)
+              (insert body "\n"))
+            (insert "\n:PROPERTIES:\n:ID: " new-node-id "\n:END:\n")
+            (save-buffer)))
 
       ;; Side Effect 2: Sync and Enrich
       (let ((node-id new-node-id))

--- a/supertag-ui-commands.el
+++ b/supertag-ui-commands.el
@@ -577,12 +577,14 @@ HEADLINE is optional headline text."
   (let* ((capture-info (supertag-capture-interactive-headline))
          (full-title (plist-get capture-info :headline))
          (selected-tags (plist-get capture-info :tags))
-          (target-file (or target-file (read-file-name "Capture to file: ")))
+         (target-file (or target-file (read-file-name "Capture to file: ")))
          ;; Optional body content below the headline
          (body (read-string "Body (optional, RET to skip): "))
-          (insert-info (supertag-ui-select-insert-position target-file))
-          (insert-pos (plist-get insert-info :position))
-          (insert-level (plist-get insert-info :level)))
+         (insert-info (supertag-ui-select-insert-position target-file))
+         (insert-pos (plist-get insert-info :position))
+         (insert-level (plist-get insert-info :level))
+         ;; Derive a title without inline #tags (since renderer adds them)
+         (title-only (string-trim (replace-regexp-in-string "\\s-+#\\w[-_[:alnum:]]*" "" full-title))))
     
     (unless insert-info
       (user-error "No valid insert position selected"))
@@ -592,7 +594,7 @@ HEADLINE is optional headline text."
         (save-excursion
           (goto-char insert-pos)
           (unless (or (bobp) (looking-back "\n" 1)) (insert "\n"))
-          (insert (make-string insert-level ?*) " " full-title "\n")
+          (insert (supertag--render-org-headline insert-level title-only selected-tags target-file nil))
           (when (and body (> (length body) 0))
             (insert body "\n"))
           (insert ":PROPERTIES:\n:ID: " (org-id-new) "\n:END:\n")


### PR DESCRIPTION
Sync/import:
- Parse Org native :tag: from headlines via org-element and merge with inline #tag into the DB.
- Read-only compatibility: does not modify files; export behavior remains unchanged.