### PR TITLE
feat(view): Implement interactive schema management panel to manage t…

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,19 @@
 * Changelog
+* [5.1.0] - 2025-09-11
+** Features
+*** Implement Interactive Schema View for Tag Management
+- Introduce `supertag-schema-view`, a dedicated buffer for visualizing and managing the entire tag hierarchy.
+- The view is fully interactive, allowing direct manipulation of the tag and field schema from a single interface.
+- **Hierarchical Display**: `:extends` relationships are shown as an indented tree for clarity.
+- **Interactive Commands**:
+  - `a`: Add a new top-level tag.
+  - On a tag: `n` (new field), `e` (set extends), `d` (delete tag).
+  - On a field: `r` (rename), `d` (delete), `M-up`/`M-down` (reorder).
+- **UX Enhancements**:
+  - `g`: Intelligent refresh that preserves cursor position.
+  - `j`/`k`/`p`: Standard navigation keys for familiar Emacs-style browsing.
+- The field reordering capability (`M-up`/`M-down`) has also been added to the Node View (`supertag-view-node.el`) for a consistent experience.
+
 * [5.0.0] - 2025-09-06
 ** Major Refactor
 *** Complete Architecture Overhaul with Pure Emacs Lisp Implementation


### PR DESCRIPTION
…ags.

   This commit introduces a powerful, interactive management panel for tags, `supertag-schema-view`. It transforms the previously read-only
   schema display into a dynamic workspace for direct tag management.

   Instead of using separate commands, users can now visualize the entire tag hierarchy and perform all management operations—creating,
   renaming, deleting, and restructuring tags and their fields—directly within this single, unified view. This streamlines the entire workflow
   of building and maintaining a complex tag system.

   Key features and enhancements include:

   **Interactive Editing & Creation**
   - `a`: Add new top-level tag anywhere in the buffer.
   - On a tag line:
     - `n`: Add a new field to the selected tag.
     - `e`: Set or clear the tag's inheritance (`:extends`). - `d`: Delete the tag and all its uses system-wide.
   - On a field line: - `r`: Rename the selected field. - `d`: Delete the selected field from its parent tag.

   **Advanced Interaction & UX**
   - `M-up`/`M-down` on a field line now reorders fields within a tag. This has been implemented in both the schema view and the node view for a consistent experience.
   - `g`: The refresh command now intelligently preserves the cursor position.
   - `j`/`k`/`p`: Standard navigation keys have been added for convenience.

   **Underlying Refactoring & Fixes**
   - The core tree-building logic was refactored into a clearer, multi-stage pipeline for improved robustness and maintainability.
   - The context-parsing logic was rewritten to be based on indentation, fixing bugs where tag/field names with special characters were not recognized.