### PR TITLE
refactor: Replace index with scan-based query layer.

### DIFF
--- a/org-supertag.el
+++ b/org-supertag.el
@@ -56,6 +56,7 @@
 ;; --- Core Components ---
 (require 'ht) ; Ensure ht is loaded before other modules that might depend on it
 (require 'supertag-core-store)
+(require 'supertag-core-scan)
 (require 'supertag-core-persistence) ; Add persistence module for data loading/saving
 (require 'supertag-core-schema)
 (require 'supertag-core-transform)
@@ -130,7 +131,7 @@ This function loads all necessary components and sets up the environment."
     ;; Add a watcher to debug unexpected changes to the store
     (add-variable-watcher 'supertag--store (lambda (sym newval op where) (debug)))
     (message "Org-Supertag system initialized."))
-
+ 
 ;; --- Hooks for persistence ---
 (add-hook 'kill-emacs-hook #'supertag-save-store)
 (add-hook 'kill-emacs-hook #'supertag-cleanup-all-timers) ; Clean up all timers on exit
@@ -142,3 +143,7 @@ This function loads all necessary components and sets up the environment."
 (provide 'org-supertag)
 
 ;;; org-supertag/supertag.el ends here
+;; Load completion UI and enable globally by default
+(ignore-errors (require 'supertag-ui-completion))
+(when (fboundp 'global-supertag-ui-completion-mode)
+  (global-supertag-ui-completion-mode 1))

--- a/supertag-core-persistence.el
+++ b/supertag-core-persistence.el
@@ -246,7 +246,7 @@ FILE is the optional file path. Defaults to supertag-db-file."
       (supertag-clear-dirty)
       ;; Rebuild indexes after loading data
       (when (hash-table-p supertag--store)
-        (supertag--rebuild-all-indexes)))
+        ))
     (unless (hash-table-p supertag--store)
       (setq supertag--store (ht-create))
       (message "Initialized empty Org-Supertag store."))))

--- a/supertag-core-scan.el
+++ b/supertag-core-scan.el
@@ -1,0 +1,131 @@
+;;; supertag-core-scan.el --- Scan-based query functions for Org-Supertag -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; This file provides simple, internal API query functions that operate by
+;; scanning the core data store. It is the dedicated layer for all
+;; scan-based queries, sitting on top of the pure storage layer
+;; (`supertag-core-store.el`) and below high-level services.
+
+;;; Code:
+
+(require 'supertag-core-store)
+
+
+;;; --- Scan-based Query Functions ---
+
+(defun supertag-index-get-nodes-by-tag (tag-name)
+  "Find all nodes with TAG-NAME by scanning the store.
+This is an O(N) operation."
+  (let ((nodes-ht (supertag-get '(:nodes)))
+        (results '()))
+    (when (hash-table-p nodes-ht)
+      (maphash (lambda (node-id node-data)
+                 (when (member tag-name (plist-get node-data :tags))
+                   (push node-id results)))
+               nodes-ht))
+    (nreverse results)))
+
+(defun supertag-index-get-nodes-by-word (word)
+  "Find all nodes containing WORD by scanning the store.
+This is an O(N) operation and performs a simple substring search."
+  (let ((nodes-ht (supertag-get '(:nodes)))
+        (results '())
+        (search-word (downcase word)))
+    (when (hash-table-p nodes-ht)
+      (maphash (lambda (node-id node-data)
+                 (let ((title (plist-get node-data :title))
+                       (content (plist-get node-data :content)))
+                   (when (or (and title (string-match-p (regexp-quote search-word) (downcase title)))
+                             (and content (string-match-p (regexp-quote search-word) (downcase content))))
+                     (push node-id results))))
+               nodes-ht))
+    (nreverse (delete-dups results))))
+
+(defun supertag-index-get-nodes-by-date-range (start-time end-time &optional date-field)
+  "Find all nodes created/modified within a date range by scanning.
+This is an O(N) operation.
+DATE-FIELD can be :created-at or :modified-at (default :created-at)."
+  (let* ((field (or date-field :created-at))
+         (nodes-ht (supertag-get '(:nodes)))
+         (matching-nodes '()))
+    (when (hash-table-p nodes-ht)
+      (maphash (lambda (node-id node-data)
+                 (let ((node-time (plist-get node-data field)))
+                   (when node-time
+                     (let ((start-check (or (null start-time) (time-less-p start-time node-time)))
+                           (end-check (or (null end-time) (time-less-p node-time end-time))))
+                       (when (and start-check end-check)
+                         (push node-id matching-nodes))))))
+               nodes-ht))
+    (nreverse matching-nodes)))
+
+(defun supertag-find-nodes-by-tag (tag-name)
+  "Find all nodes with TAG-NAME by scanning the store.
+This is an O(N) operation.
+TAG-NAME is the name of the tag to search for.
+Returns a list of (node-id . node-data) pairs."
+  (let ((nodes-ht (supertag-get '(:nodes)))
+        (results '()))
+    (when (hash-table-p nodes-ht)
+      (maphash (lambda (node-id node-data)
+                 (when (and node-data (member tag-name (plist-get node-data :tags)))
+                   (push (cons node-id node-data) results)))
+               nodes-ht))
+    (nreverse results)))
+
+(defun supertag-find-nodes-by-file (file-path)
+  "Find all nodes located in FILE-PATH.
+Returns a list of (node-id . node-data) pairs."
+  (let ((nodes-collection (supertag-get '(:nodes)))
+        (found-nodes '()))
+    (when (hash-table-p nodes-collection)
+      (maphash
+       (lambda (id node-data)
+         ;; Safely extract :file and ensure it's a string
+         (when-let* ((node-file (and node-data (plist-get node-data :file)))
+                     ((stringp node-file)))
+           ;; Direct string comparison without path normalization
+           (when (equal node-file file-path)
+             (push (cons id node-data) found-nodes))))
+       nodes-collection))
+    (nreverse found-nodes)))
+
+(defun supertag-find-nodes-by-title (title-pattern)
+  "Find all nodes whose title matches TITLE-PATTERN by scanning the store.
+TITLE-PATTERN is a regular expression string.
+Returns a list of (node-id . node-data) pairs."
+  (let ((nodes-ht (supertag-get '(:nodes)))
+        (results '()))
+    (when (hash-table-p nodes-ht)
+      (maphash (lambda (node-id node-data)
+                 (when (and node-data
+                            (plist-get node-data :title)
+                            (string-match-p title-pattern (plist-get node-data :title)))
+                   (push (cons node-id node-data) results)))
+               nodes-ht))
+    (nreverse results)))
+
+(defun supertag-find-nodes (predicates)
+  "Find nodes satisfying PREDICATES by scanning the store.
+PREDICATES is a list of predicate functions. Each predicate function receives (id . data) and returns t or nil.
+Returns a list of (node-id . node-data) pairs that satisfy all predicates."
+  (let ((nodes-ht (supertag-get '(:nodes)))
+        (results '()))
+    (when (hash-table-p nodes-ht)
+      (maphash (lambda (node-id node-data)
+                 (when (and node-data
+                            (cl-every (lambda (pred) (funcall pred node-id node-data)) predicates))
+                   (push (cons node-id node-data) results)))
+               nodes-ht))
+    (nreverse results)))
+
+(defun supertag-index-node-has-tag-p (node-id tag-name)
+  "Check if a node has a specific tag by direct lookup.
+This is an O(1) operation on the node data."
+  (when-let ((node-data (supertag-get (list :nodes node-id))))
+    (member tag-name (plist-get node-data :tags))))
+
+(provide 'supertag-core-scan)
+
+
+;;; supertag-core-scan.el ends here

--- a/supertag-core-store.el
+++ b/supertag-core-store.el
@@ -16,14 +16,6 @@
   "The central hash table for all application state.
 Data is stored in a tree-like structure using nested hash tables.")
 
-(defvar supertag--store-indexes nil
-  "The index hash table for fast query performance.
-Contains multiple sub-indexes:
-  :tags - Hash table mapping tag names to lists of node IDs
-  :words - Inverted index mapping words to lists of node IDs
-  :fields - Hash table mapping field keys to value->node-id mappingswojt
-  :dates - Hash table for date-based queries")
-
 ;; Direct storage is now the default and only mode for optimal performance
 ;; This hybrid architecture combines old system performance with new system features
 
@@ -43,9 +35,6 @@ ID is the entity ID. DATA is the plist data."
                             (gethash collection supertag--store))
                     (gethash id (gethash collection supertag--store)))))
     (puthash id data collection-table)
-    ;; Update indexes for nodes
-    (when (eq collection :nodes)
-      (supertag--update-indexes-for-node id old-data data))
     ;; Emit change event
     (supertag-emit-event :store-changed (list collection id) nil data)
     data))
@@ -65,7 +54,7 @@ COLLECTION is the collection name. ID is the entity ID."
 
 (defun supertag--get-nested-ht (table path &optional default)
   "Get a value from a nested hash table at PATH.
-TABLE is the hash table. PATH is a list of keys (e.g., '(:nodes \"123\" :title)).
+TABLE is the hash table. PATH is a list of keys (e.g., '(:nodes "123" :title)).
 Returns DEFAULT if path not found."
   (if (null path)
       table
@@ -101,7 +90,7 @@ Returns t if a value was removed, nil otherwise."
           (let ((subtable (gethash key table)))
             (when (hash-table-p subtable)
               (supertag--remove-nested-ht subtable rest)))
-        (remhash key table)))))
+        (remhash key table))))) 
 
 ;;; --- Change Notification ---
 
@@ -137,20 +126,9 @@ This function acts as a bridge to the actual notification system in `supertag-co
   (unless (hash-table-p supertag--store)
     (setq supertag--store (ht-create)))
   
-  (let ((old-value (supertag-get path))
-        (full-old-node-data nil))
-    ;; If we are updating any part of a node, capture its full state BEFORE the change.
-    (when (and (>= (length path) 2) (eq (car path) :nodes))
-      (setq full-old-node-data (supertag-get (list :nodes (cadr path)))))
-
+  (let ((old-value (supertag-get path)))
     (when (not (equal old-value value))
       (supertag--set-nested-ht supertag--store path value)
-      ;; If a node was updated, trigger a full re-index for that node
-      ;; using the before and after states.
-      (when full-old-node-data
-        (let* ((node-id (cadr path))
-               (full-new-node-data (supertag-get (list :nodes node-id))))
-          (supertag--update-indexes-for-node node-id full-old-node-data full-new-node-data)))
       (supertag--notify-change path old-value value)
       ;; Emit a generic store-changed event for persistence layer to listen to
       (supertag-emit-event :store-changed path old-value value))
@@ -172,258 +150,13 @@ This function acts as a bridge to the actual notification system in `supertag-co
     old-value))
 
 (defun supertag-store-clear ()
-  "Clear the entire data store and all indexes.
+  "Clear the entire data store.
 This is primarily intended for testing and system resets."
   (interactive)
   (setq supertag--store (ht-create))
-  (setq supertag--store-indexes (ht-create))
-  (supertag--ensure-indexes-initialized) ; Re-initialize the basic index structure
-  (message "Supertag store and indexes have been cleared."))
+  (message "Supertag store has been cleared."))
 
-;;; --- Index Management ---
 
-(defun supertag--ensure-indexes-initialized ()
-  "Ensure all indexes are properly initialized."
-  (unless supertag--store-indexes
-    (setq supertag--store-indexes (ht-create))
-    (puthash :tags (ht-create) supertag--store-indexes)
-    (puthash :words (ht-create) supertag--store-indexes)
-    (puthash :fields (ht-create) supertag--store-indexes)
-    (puthash :dates (ht-create) supertag--store-indexes)))
-
-(defun supertag--update-indexes-for-node (node-id old-data new-data)
-  "Update all indexes for a node change.
-NODE-ID is the node identifier.
-OLD-DATA is the previous node data (nil if creating).
-NEW-DATA is the new node data (nil if deleting)."
-  (supertag--ensure-indexes-initialized)
-  
-  ;; Remove old data from indexes
-  (when old-data
-    (supertag--remove-from-tag-index node-id old-data)
-    (supertag--remove-from-word-index node-id old-data)
-    (supertag--remove-from-date-index node-id old-data))
-  
-  ;; Add new data to indexes
-  (when new-data
-    (supertag--add-to-tag-index node-id new-data)
-    (supertag--add-to-word-index node-id new-data)
-    (supertag--add-to-date-index node-id new-data)))
-
-(defun supertag--add-to-tag-index (node-id node-data)
-  "Add node to tag index."
-  (let ((tags (plist-get node-data :tags))
-        (tag-index (gethash :tags supertag--store-indexes)))
-    (when tags
-      (dolist (tag tags)
-        (let ((nodes-list (gethash tag tag-index)))
-          (unless (member node-id nodes-list)
-            (puthash tag (cons node-id nodes-list) tag-index)))))))
-
-(defun supertag--remove-from-tag-index (node-id node-data)
-  "Remove node from tag index."
-  (let ((tags (plist-get node-data :tags))
-        (tag-index (gethash :tags supertag--store-indexes)))
-    (when tags
-      (dolist (tag tags)
-        (let ((nodes-list (gethash tag tag-index)))
-          (when nodes-list
-            (puthash tag (remove node-id nodes-list) tag-index)))))))
-
-(defun supertag--add-to-word-index (node-id node-data)
-  "Add node to word index for full-text search."
-  (let ((title (plist-get node-data :title))
-        (content (plist-get node-data :content))
-        (word-index (gethash :words supertag--store-indexes)))
-    ;; Index words from title
-    (when title
-      (supertag--index-words-from-text title node-id word-index))
-    ;; Index words from content
-    (when content
-      (supertag--index-words-from-text content node-id word-index))))
-
-(defun supertag--remove-from-word-index (node-id node-data)
-  "Remove node from word index."
-  (let ((title (plist-get node-data :title))
-        (content (plist-get node-data :content))
-        (word-index (gethash :words supertag--store-indexes)))
-    ;; Remove words from title
-    (when title
-      (supertag--unindex-words-from-text title node-id word-index))
-    ;; Remove words from content
-    (when content
-      (supertag--unindex-words-from-text content node-id word-index))))
-
-(defun supertag--add-to-date-index (node-id node-data)
-  "Add node to date index."
-  (let ((created-at (plist-get node-data :created-at))
-        (modified-at (plist-get node-data :modified-at))
-        (date-index (gethash :dates supertag--store-indexes)))
-    (when created-at
-      (let ((created-nodes (gethash :created-at date-index)))
-        (unless (member node-id created-nodes)
-          (puthash :created-at (cons (cons node-id created-at) created-nodes) date-index))))
-    (when modified-at
-      (let ((modified-nodes (gethash :modified-at date-index)))
-        (unless (member node-id modified-nodes)
-          (puthash :modified-at (cons (cons node-id modified-at) modified-nodes) date-index))))))
-
-(defun supertag--remove-from-date-index (node-id node-data)
-  "Remove node from date index."
-  (let ((date-index (gethash :dates supertag--store-indexes)))
-    (let ((created-nodes (gethash :created-at date-index)))
-      (when created-nodes
-        (puthash :created-at (cl-remove node-id created-nodes :key #'car) date-index)))
-    (let ((modified-nodes (gethash :modified-at date-index)))
-      (when modified-nodes
-        (puthash :modified-at (cl-remove node-id modified-nodes :key #'car) date-index)))))
-
-(defun supertag--index-words-from-text (text node-id word-index)
-  "Extract and index words from TEXT for NODE-ID."
-  (when (stringp text)
-    ;; Simple word extraction: split by non-word characters and index
-    (let ((words (split-string (downcase text) "[^[:word:]]+" t)))
-      (dolist (word words)
-        (when (> (length word) 2) ; Only index words longer than 2 characters
-          (let ((nodes-list (gethash word word-index)))
-            (unless (member node-id nodes-list)
-              (puthash word (cons node-id nodes-list) word-index))))))))
-
-(defun supertag--unindex-words-from-text (text node-id word-index)
-  "Remove words from TEXT for NODE-ID from word index."
-  (when (stringp text)
-    (let ((words (split-string (downcase text) "[^[:word:]]+" t)))
-      (dolist (word words)
-        (when (> (length word) 2)
-          (let ((nodes-list (gethash word word-index)))
-            (when nodes-list
-              (puthash word (remove node-id nodes-list) word-index))))))))
-
-;;; --- Index Query Functions ---
-
-(defun supertag-index-get-nodes-by-tag (tag-name)
-  "Fast query: get all nodes with TAG-NAME using tag index."
-  (supertag--ensure-indexes-initialized)
-  (let ((tag-index (gethash :tags supertag--store-indexes)))
-    (let ((result (or (gethash tag-name tag-index) '())))
-      ;;(message "Supertag Store Debug: Tag '%s' index lookup returned %d nodes: %s" tag-name (length result) result)
-      result)))
-
-(defun supertag-index-get-nodes-by-word (word)
-  "Fast query: get all nodes containing WORD using word index."
-  (supertag--ensure-indexes-initialized)
-  (let ((word-index (gethash :words supertag--store-indexes)))
-    (or (gethash (downcase word) word-index) '())))
-
-(defun supertag-index-get-nodes-by-date-range (start-time end-time &optional date-field)
-  "Fast query: get all nodes created/modified within date range using date index.
-DATE-FIELD can be :created-at or :modified-at (default :created-at)."
-  (supertag--ensure-indexes-initialized)
-  (let* ((field (or date-field :created-at))
-         (date-index (gethash :dates supertag--store-indexes))
-         (date-entries (gethash field date-index))
-         (matching-nodes '()))
-    (dolist (entry date-entries)
-      (let ((node-id (car entry))
-            (node-time (cdr entry)))
-        (when (and node-time (listp node-time) (>= (length node-time) 2))
-          ;; For 'after' queries: node-time should be LATER than start-time
-          ;; For 'before' queries: node-time should be EARLIER than end-time
-          ;; Fix: For 'after' queries, we want nodes with node-time > start-time
-          ;; Fix: For 'before' queries, we want nodes with node-time < end-time
-          (let ((start-check (or (null start-time) (time-less-p start-time node-time)))
-                (end-check (or (null end-time) (time-less-p node-time end-time))))
-            ;;(message "Supertag Store Debug: Checking node %s with time %s" node-id node-time)
-            ;;(message "Supertag Store Debug: Start time: %s, End time: %s" start-time end-time)
-            ;;(message "Supertag Store Debug: Start check: %s, End check: %s" start-check end-check)
-            (when (and start-check end-check)
-              ;;(message "Supertag Store Debug: Node %s matches date range" node-id)
-              (push node-id matching-nodes))))))
-    ;;(message "Supertag Store Debug: Date range query returned %d nodes: %s" (length matching-nodes) matching-nodes)
-    matching-nodes))
-
-(defun supertag--rebuild-all-indexes ()
-  "Rebuild all indexes from scratch based on current store data.
-Useful for initialization or after major data changes."
-  (supertag--ensure-indexes-initialized)
-  
-  ;; Clear all indexes
-  (puthash :tags (ht-create) supertag--store-indexes)
-  (puthash :words (ht-create) supertag--store-indexes)
-  (puthash :fields (ht-create) supertag--store-indexes)
-  (puthash :dates (ht-create) supertag--store-indexes)
-  
-  ;; Rebuild from current data
-  (let ((nodes-collection (gethash :nodes supertag--store)))
-    (when (hash-table-p nodes-collection)
-      (maphash
-       (lambda (node-id node-data)
-         (supertag--update-indexes-for-node node-id nil node-data))
-       nodes-collection))))
-
-;;; --- High-performance API Query Functions (for internal modules) ---
-
-(defun supertag-find-nodes-by-tag (tag-name)
-  "Find all nodes that have TAG-NAME using index for optimal performance.
-TAG-NAME is the name of the tag to search for.
-Returns a list of (node-id . node-data) pairs."
-  (let ((node-ids (supertag-index-get-nodes-by-tag tag-name))
-        (results '()))
-    (dolist (node-id node-ids)
-      (when-let ((node-data (supertag-store-direct-get :nodes node-id)))
-        (push (cons node-id node-data) results)))
-    (nreverse results)))
-
-(defun supertag-find-nodes-by-file (file-path)
-  "Find all nodes located in FILE-PATH.
-Returns a list of (node-id . node-data) pairs."
-  (let ((nodes-collection (supertag-get '(:nodes)))
-        (found-nodes '()))
-    (when (hash-table-p nodes-collection)
-      (maphash
-       (lambda (id node-data)
-         ;; Safely extract :file and ensure it's a string
-         (when-let* ((node-file (and node-data (plist-get node-data :file)))
-                     ((stringp node-file)))
-           ;; Direct string comparison without path normalization
-           (when (equal node-file file-path)
-             (push (cons id node-data) found-nodes))))
-       nodes-collection))
-    (nreverse found-nodes)))
-
-(defun supertag-find-nodes-by-title (title-pattern)
-  "Find all nodes whose title matches TITLE-PATTERN using optimized search.
-TITLE-PATTERN is a regular expression string.
-Returns a list of (node-id . node-data) pairs."
-  (let ((all-nodes (supertag-query '(:nodes)))
-        (results '()))
-    (dolist (node-pair all-nodes)
-      (let ((node-id (car node-pair))
-            (node-data (cdr node-pair)))
-        (when (string-match-p title-pattern (plist-get node-data :title))
-          (push (cons node-id node-data) results))))
-    (nreverse results)))
-
-(defun supertag-find-nodes (predicates)
-  "Find nodes using multiple predicates with optimized filtering.
-PREDICATES is a list of predicate functions. Each predicate function receives (id . data) and returns t or nil.
-Returns a list of (node-id . node-data) pairs that satisfy all predicates."
-  (let ((all-nodes (supertag-query '(:nodes)))
-        (results '()))
-    (dolist (node-pair all-nodes)
-      (let ((id (car node-pair))
-            (data (cdr node-pair)))
-        (when (cl-every (lambda (pred) (funcall pred id data)) predicates)
-          (push (cons id data) results))))
-    (nreverse results)))
-
-(defun supertag-index-node-has-tag-p (node-id tag-name)
-  "Check if a node has a specific tag using index for optimal performance.
-NODE-ID is the node identifier.
-TAG-NAME is the tag name to check.
-Returns t if the node has the tag, nil otherwise."
-  (let ((node-tags (supertag-index-get-nodes-by-tag tag-name)))
-    (member node-id node-tags)))
 
 (provide 'supertag-core-store)
 

--- a/supertag-services-embed.el
+++ b/supertag-services-embed.el
@@ -34,7 +34,7 @@ Title is NOT updated from the embed block in this new architecture."
               (goto-char (point-min))
               (if (re-search-forward (format ":ID:[ \t]+%s" (regexp-quote source-id)) nil t)
                   (progn
-                    (message "DEBUG: (3b) Found ID in file %s. Rendering..." file-path)
+                    ;;(message "DEBUG: (3b) Found ID in file %s. Rendering..." file-path)
                     (org-back-to-heading t)
                     (let* ((element (org-element-at-point))
                            (start (org-element-property :begin element))
@@ -42,15 +42,11 @@ Title is NOT updated from the embed block in this new architecture."
                       (delete-region start end)
                       (goto-char start)
                       (insert (supertag--generate-org-content (list node-data)))
-                      (save-buffer)
-                      (message "DEBUG: (3c) Buffer for %s saved." file-path)))
-                (message "DEBUG: ERROR - Could not find ID %s in file %s" source-id file-path))))
-        (message "DEBUG: ERROR - File path '%s' for node %s not found or invalid." file-path source-id))
-    (message "DEBUG: ERROR - Could not find node %s in DB during render." source-id)))      
+                      (save-buffer)))))))))      
 
 (defun supertag-embed-sync-modified-blocks ()
   "Sync all modified embed blocks in current buffer back to their sources."
-  (message "DEBUG: (1a) Running supertag-embed-sync-modified-blocks on %s" (buffer-name))
+  ;;(message "DEBUG: (1a) Running supertag-embed-sync-modified-blocks on %s" (buffer-name))
   (save-excursion
     (goto-char (point-min))
     (let ((synced-count 0))
@@ -60,18 +56,16 @@ Title is NOT updated from the embed block in this new architecture."
                (current-content (and inner-region
                                      (buffer-substring-no-properties
                                       (car inner-region) (cdr inner-region)))))
-          (message "DEBUG: (1b) Found embed block for ID %s" source-id)
+          ;;(message "DEBUG: (1b) Found embed block for ID %s" source-id)
           (if current-content
               (progn
-                (message "DEBUG: (2) Calling DB update...")
+                ;;(message "DEBUG: (2) Calling DB update...")
                 (supertag-services-embed--update-node-in-db source-id current-content)
-                (message "DEBUG: (3) Calling render-to-file...")
+                ;;(message "DEBUG: (3) Calling render-to-file...")
                 (supertag-services-embed--render-node-to-file source-id)
                 (setq synced-count (1+ synced-count)))
-            (message "DEBUG: (1c) No content found in embed block. Skipping."))))
-      (if (> synced-count 0)
-          (message "DEBUG: (4) Sync process finished for %d embed block(s)." synced-count)
-        (message "DEBUG: (4) No embed blocks found or synced in this run."))
+            ;;(message "DEBUG: (1c) No content found in embed block. Skipping.")
+            )))
       synced-count)))
 
 ;;; --- Refresh Logic (Remains largely the same) ---

--- a/supertag-services-query.el
+++ b/supertag-services-query.el
@@ -1,18 +1,20 @@
 ;;; org-supertag/services/query.el --- Query system for Org-Supertag -*- lexical-binding: t; -*-
 
 ;;; ⚠️  ARCHITECTURE WARNING ⚠️
-;; This file should ONLY contain S-expression query engine functionality.
-;; For internal API queries, use the index functions in supertag-store.el:
-;; - supertag-index-get-nodes-by-tag      (for tag-based queries)
-;; - supertag-index-get-nodes-by-word     (for full-text search)  
-;; - supertag-index-get-nodes-by-date-range (for time-based queries)
-;; - supertag-index-node-has-tag-p        (for boolean checks)
+;; This file should ONLY contain the high-level S-expression query engine.
+;;
+;; For simple, internal API queries, use the functions in `supertag-core-scan.el`.
+;; That file contains all scan-based query functions, such as:
 ;; - supertag-find-nodes-by-tag           (for complete node data)
 ;; - supertag-find-nodes-by-file          (for file-based queries)
 ;; - supertag-find-nodes-by-title         (for title pattern matching)
 ;; - supertag-find-nodes                  (for complex predicate filtering)
+;; - supertag-index-get-nodes-by-tag      (for tag-based queries, returns IDs)
+;; - supertag-index-get-nodes-by-word     (for full-text search, returns IDs)
+;; - supertag-index-get-nodes-by-date-range (for time-based queries, returns IDs)
+;; - supertag-index-node-has-tag-p        (for boolean checks)
 ;;
-;; DO NOT add any simple query functions to this file!
+;; DO NOT add any simple, internal query functions to this file!
 ;;
 ;;; Commentary:
 ;; This file provides S-expression query engine for the Org-Supertag

--- a/supertag-ui-completion.el
+++ b/supertag-ui-completion.el
@@ -1,0 +1,135 @@
+;;; supertag-ui-completion.el --- Simple tag completion -*- lexical-binding: t; -*-
+
+;; Simple, working tag completion for org-supertag.
+;; Type `#` followed by tag name to get completion.
+
+;;; Code:
+
+(require 'org)
+(require 'org-id nil t)
+
+;; Optional requires
+(require 'supertag-ops-tag nil t)
+(require 'supertag-ops-node nil t)
+
+;;; Core Functions
+
+(defun supertag-ui-completion--tag-bounds ()
+  "Return (START . END) for tag name after `#`, or nil."
+  (let ((end (point)))
+    (save-excursion
+      (let ((pos (point)))
+        ;; Skip back over tag characters
+        (while (and (> pos (point-min))
+                    (let ((ch (char-before pos)))
+                      (or (and ch (or (= (char-syntax ch) ?w)
+                                      (= (char-syntax ch) ?_)
+                                      (= ch ?-))))))
+          (setq pos (1- pos)))
+        ;; Check if we have `#` before the tag
+        (when (and (> pos (point-min))
+                   (= (char-before pos) ?#))
+          (cons pos end))))))
+
+(defun supertag-ui-completion--get-tag-candidates ()
+  "Get list of tag candidates."
+  (cond
+   ;; Try to get from database
+   ((fboundp 'supertag-ops-tag-list)
+    (ignore-errors 
+      (let ((tags (supertag-ops-tag-list)))
+        (mapcar (lambda (tag)
+                  (if (stringp tag) tag (format "%s" tag)))
+                tags))))
+   ;; Fallback: scan buffer for tags
+   (t
+    (let (acc)
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward "#\\([[:alnum:]_-]+\\)" nil t)
+          (push (match-string-no-properties 1) acc)))
+      (delete-dups acc)))))
+
+(defun supertag-ui-completion--apply-tag (tagname)
+  "Apply TAGNAME to current node."
+  (condition-case nil
+      (save-excursion
+        ;; Go to the heading of current section
+        (unless (org-at-heading-p)
+          (org-back-to-heading t))
+        
+        (let ((node-id (or (org-id-get) (org-id-get-create))))
+          (when node-id
+            ;; Ensure node exists in database
+            (when (and (fboundp 'supertag-node-get)
+                       (fboundp 'supertag-node-create)
+                       (not (supertag-node-get node-id)))
+              (let ((title (nth 4 (org-heading-components))))
+                (supertag-node-create `(:id ,node-id :title ,(or title "Untitled")))))
+            
+            ;; Add tag to node
+            (cond
+             ((fboundp 'supertag-node-add-tag)
+              (supertag-node-add-tag node-id tagname)
+              (message "Added tag '%s'" tagname))
+             (t
+              (message "Tag '%s' added to buffer only" tagname))))))
+    (error
+     (message "Could not find heading for tag '%s'" tagname))))
+
+(defun supertag-ui-completion--tag-exit (candidate _status)
+  "Called after user selects tag CANDIDATE."
+  (condition-case err
+      (progn
+        (supertag-ui-completion--apply-tag candidate)
+        ;; Add space after tag
+        (unless (looking-at-p "\\s-")
+          (insert " ")))
+    (error (message "Tag completion error: %S" err))))
+
+;;; CAPF
+
+(defun supertag-ui-completion--capf ()
+  "Completion-at-point function for tags."
+  (when-let ((bounds (supertag-ui-completion--tag-bounds)))
+    (let ((start (car bounds))
+          (end (cdr bounds))
+          (candidates (supertag-ui-completion--get-tag-candidates)))
+      (list start end candidates
+            :exit-function #'supertag-ui-completion--tag-exit
+            :category 'supertag-tag))))
+
+;;; Auto-trigger
+
+(defun supertag-ui-completion--auto-trigger ()
+  "Auto-trigger completion when typing `#`."
+  (when (eq (char-before) ?#)
+    (completion-at-point)))
+
+;;; Minor Mode
+
+;;;###autoload
+(define-minor-mode supertag-ui-completion-mode
+  "Simple tag completion for org-supertag."
+  :lighter " ST-C"
+  (if supertag-ui-completion-mode
+      (progn
+        (add-hook 'completion-at-point-functions #'supertag-ui-completion--capf nil t)
+        (add-hook 'post-self-insert-hook #'supertag-ui-completion--auto-trigger nil t))
+    (remove-hook 'completion-at-point-functions #'supertag-ui-completion--capf t)
+    (remove-hook 'post-self-insert-hook #'supertag-ui-completion--auto-trigger t)))
+
+;;;###autoload
+(defun supertag-ui-completion-enable ()
+  "Enable tag completion in org-mode buffers."
+  (when (derived-mode-p 'org-mode)
+    (supertag-ui-completion-mode 1)))
+
+;;;###autoload
+(define-globalized-minor-mode global-supertag-ui-completion-mode
+  supertag-ui-completion-mode
+  supertag-ui-completion-enable)
+
+(provide 'supertag-ui-completion)
+
+;;; supertag-ui-completion.el ends here


### PR DESCRIPTION
The previous in-memory indexing system was a source of complexity and subtle bugs. This commit removes it in favor of a simpler and more robust full-scan approach for all internal API queries.

The main architectural change is the introduction of a new file, . This file now serves as a dedicated layer for all simple, scan-based internal query functions.

This refactoring moves query logic out of , allowing it to revert to its sole responsibility as a pure storage module. This clarifies the separation of concerns and improves the stability of the core architecture.