### PR TITLE
fix(init): Fix startup race condition by using emacs-startup-hook

### DIFF
--- a/org-supertag.el
+++ b/org-supertag.el
@@ -137,7 +137,8 @@ This function loads all necessary components and sets up the environment."
 (add-hook 'kill-emacs-hook #'supertag-cleanup-all-timers) ; Clean up all timers on exit
 (add-hook 'kill-emacs-hook #'supertag-sync-save-state) ; Save sync state on exit
 (add-hook 'kill-emacs-hook #'supertag-sync-stop-auto-sync) ; Stop auto-sync on exit
-(add-hook 'after-init-hook #'supertag-init) ; Initialize on Emacs start, after basic init
+;;(add-hook 'after-init-hook #'supertag-init) ; Initialize on Emacs start, after basic init
+(add-hook 'emacs-startup-hook #'supertag-init)
 (add-hook 'org-mode-hook #'supertag-sync-setup-realtime-hooks) ; Add sync hook to all org buffers
 
 (provide 'org-supertag)

--- a/supertag-performance-optimizer.el
+++ b/supertag-performance-optimizer.el
@@ -254,7 +254,8 @@
     ;; Run garbage collection
     (garbage-collect)
     
-    (message "Memory cleanup completed: %d items freed" freed-items)))
+    ;;(message "Memory cleanup completed: %d items freed" freed-items)
+    ))
 
 ;;; --- Performance Monitoring ---
 


### PR DESCRIPTION
    can fire before  is fully initialized on
   some systems (e.g., NixOS), causing initialization to fail silently.

   Moving to  ensures we run late enough for the
   org-mode environment to be ready, fixing the race.