### PR TITLE
fix: resolve tab-width warnings and embed block sync issues

### DIFF
--- a/supertag-ops-embed.el
+++ b/supertag-ops-embed.el
@@ -7,18 +7,35 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'supertag-core-store)
+(require 'supertag-services-query)
 
 (defun supertag-ops-embed-find-by-source-file (source-file)
   "Find all embed blocks that reference nodes from SOURCE-FILE.
-Returns a list of source-ids (node IDs) that have embed blocks referencing them."
-  (let ((source-ids '()))
-    ;; This is a simplified implementation
-    ;; In a full implementation, this would search through all embed databases
-    ;; to find which nodes from source-file are embedded elsewhere
+Returns a list of source-ids (node IDs) that have embed blocks referencing them.
+This function searches all open buffers for embed blocks that reference nodes from the source file."
+  (let ((source-ids '())
+        (nodes-in-file nil))
     (when (and source-file (file-exists-p source-file))
-      ;; For now, return an empty list
-      ;; TODO: Implement proper lookup in embed sync database
-      source-ids)))
+      ;; First, find all nodes that belong to this source file
+      (let ((file-nodes (supertag-find-nodes-by-file source-file)))
+        (setq nodes-in-file (mapcar #'car file-nodes))) ; Extract node IDs
+      
+      ;; Then, search all open buffers for embed blocks referencing these nodes
+      (dolist (buf (buffer-list))
+        (when (buffer-live-p buf)
+          (with-current-buffer buf
+            (when (buffer-file-name)
+              (save-excursion
+                (goto-char (point-min))
+                (while (re-search-forward "^#\\+begin_embed:\\s-+\\([a-zA-Z0-9-]+\\)" nil t)
+                  (let ((embed-id (match-string 1)))
+                    ;; Check if this embed-id is one of the nodes from source-file
+                    (when (member embed-id nodes-in-file)
+                      (push embed-id source-ids)))))))))
+      
+      ;; Return unique list of source-ids
+      (cl-delete-duplicates source-ids :test #'equal))))
 
 (provide 'supertag-ops-embed)
 ;;; supertag-ops-embed.el ends here

--- a/supertag-services-embed.el
+++ b/supertag-services-embed.el
@@ -13,60 +13,73 @@
 (defun supertag-services-embed--update-node-in-db (source-id new-embed-content)
   "Update a node's content in the database from an embed block.
 Title is NOT updated from the embed block in this new architecture."
-  (message "DEBUG: (2a) Running update-node-in-db for %s" source-id)
+  ;;(message "DEBUG: (2a) Running update-node-in-db for %s" source-id)
   (when-let ((old-node-data (supertag-get (list :nodes source-id))))
     (let ((updated-node-data (cl-copy-list old-node-data)))
       ;; The entire block content is the new node content.
       (setf (plist-get updated-node-data :content) new-embed-content)
       ;; Use the existing transaction-safe operation to update the node
       (supertag-node-create updated-node-data)
-      (message "DEBUG: (2c) DB update called via supertag-node-create."))
-    (message "DEBUG: ERROR - Could not find node %s in DB during update." source-id)))
+      ;;(message "DEBUG: (2c) DB update called via supertag-node-create.")
+      )
+    ;;(message "DEBUG: ERROR - Could not find node %s in DB during update." source-id)
+    ))
 
 (defun supertag-services-embed--render-node-to-file (source-id)
-  "Renders a node from the database to its source file."
-  (message "DEBUG: (3a) Running render-node-to-file for %s" source-id)
-  (if-let* ((node-data (supertag-get (list :nodes source-id)))
-            (file-path (plist-get node-data :file)))
-      (if (and file-path (file-exists-p file-path))
-          (with-current-buffer (find-file-noselect file-path)
-            (save-excursion
-              (goto-char (point-min))
-              (if (re-search-forward (format ":ID:[ \t]+%s" (regexp-quote source-id)) nil t)
-                  (progn
-                    ;;(message "DEBUG: (3b) Found ID in file %s. Rendering..." file-path)
-                    (org-back-to-heading t)
-                    (let* ((element (org-element-at-point))
-                           (start (org-element-property :begin element))
-                           (end (org-element-property :end element)))
-                      (delete-region start end)
-                      (goto-char start)
-                      (insert (supertag--generate-org-content (list node-data)))
-                      (save-buffer)))))))))      
+  "Renders a node's CONTENT from the database to its source file.
+Only updates the content section, preserving the headline and properties.
+Uses find-file-noselect with minimal side effects."
+  (when-let* ((node-data (supertag-get (list :nodes source-id)))
+              (file-path (plist-get node-data :file)))
+    (when (file-exists-p file-path)
+      ;; Use find-file-noselect but suppress hooks that might interfere
+      (let* ((inhibit-modification-hooks t)
+             (target-buffer (let ((find-file-hook nil)        ; Disable file hooks
+                                  (after-find-file nil))       ; Disable after-find-file
+                              (find-file-noselect file-path))))
+        (with-current-buffer target-buffer
+          (save-excursion
+            (goto-char (point-min))
+            (when (re-search-forward (format ":ID:[ \t]+%s" (regexp-quote source-id)) nil t)
+              ;; Find the end of the properties drawer
+              (let ((props-end (save-excursion
+                                 (when (re-search-forward "^[ \t]*:END:[ \t]*$" nil t)
+                                   (forward-line 1)
+                                   (point)))))
+                (when props-end
+                  ;; Find the end of this node's content (before next heading or end of buffer)
+                  (org-back-to-heading t)
+                  (let* ((element (org-element-at-point))
+                         (node-end (org-element-property :end element))
+                         (new-content (plist-get node-data :content)))
+                    ;; Delete old content (from end of properties to end of node)
+                    (delete-region props-end node-end)
+                    ;; Insert new content
+                    (goto-char props-end)
+                    (when (and new-content (not (string-empty-p new-content)))
+                      (insert new-content)
+                      (unless (string-suffix-p "\n" new-content)
+                        (insert "\n")))
+                    (save-buffer)))))))))))
 
 (defun supertag-embed-sync-modified-blocks ()
-  "Sync all modified embed blocks in current buffer back to their sources."
-  ;;(message "DEBUG: (1a) Running supertag-embed-sync-modified-blocks on %s" (buffer-name))
-  (save-excursion
-    (goto-char (point-min))
-    (let ((synced-count 0))
-      (while (re-search-forward "^#\\+begin_embed:\\s-+\\([a-zA-Z0-9-]+\\)" nil t)
-        (let* ((source-id (match-string 1))
-               (inner-region (supertag-ui-embed-get-inner-block-region source-id))
-               (current-content (and inner-region
-                                     (buffer-substring-no-properties
-                                      (car inner-region) (cdr inner-region)))))
-          ;;(message "DEBUG: (1b) Found embed block for ID %s" source-id)
-          (if current-content
-              (progn
-                ;;(message "DEBUG: (2) Calling DB update...")
-                (supertag-services-embed--update-node-in-db source-id current-content)
-                ;;(message "DEBUG: (3) Calling render-to-file...")
-                (supertag-services-embed--render-node-to-file source-id)
-                (setq synced-count (1+ synced-count)))
-            ;;(message "DEBUG: (1c) No content found in embed block. Skipping.")
-            )))
-      synced-count)))
+  "Sync all modified embed blocks in current buffer back to their sources.
+This function is designed to minimize interference with other packages."
+  (let ((inhibit-modification-hooks t))  ; Prevent other hooks from firing
+    (save-excursion
+      (goto-char (point-min))
+      (let ((synced-count 0))
+        (while (re-search-forward "^#\\+begin_embed:\\s-+\\([a-zA-Z0-9-]+\\)" nil t)
+          (let* ((source-id (match-string 1))
+                 (inner-region (supertag-ui-embed-get-inner-block-region source-id))
+                 (current-content (and inner-region
+                                       (buffer-substring-no-properties
+                                        (car inner-region) (cdr inner-region)))))
+            (when current-content
+              (supertag-services-embed--update-node-in-db source-id current-content)
+              (supertag-services-embed--render-node-to-file source-id)
+              (setq synced-count (1+ synced-count)))))
+        synced-count))))
 
 ;;; --- Refresh Logic (Remains largely the same) ---
 
@@ -103,17 +116,26 @@ Title is NOT updated from the embed block in this new architecture."
 ;;; --- Save Hooks ---
 
 (defun supertag-services-embed-on-source-save ()
-  "Handle source file saves - refresh all embeds that reference this file."
+  "Handle source file saves - refresh all embeds that reference this file.
+This function runs OUTSIDE of inhibit-modification-hooks to allow buffer updates."
+  ;;(message "DEBUG-EMBED: [HOOK] on-source-save called for file: %s" (buffer-file-name))
   (let ((current-file (buffer-file-name)))
     (when current-file
+      ;;(message "DEBUG-EMBED: Checking %d buffers for embed blocks" (length (buffer-list)))
       (dolist (buf (buffer-list))
         (when (buffer-live-p buf)
           (with-current-buffer buf
+            ;;(message "DEBUG-EMBED: Checking buffer: %s, file: %s" (buffer-name) (buffer-file-name))
             (when (and (buffer-file-name)
                        (not (string= (buffer-file-name) current-file)))
+              ;;(message "DEBUG-EMBED: Calling find-by-source-file for: %s" current-file)
               (let ((source-ids (supertag-ops-embed-find-by-source-file current-file)))
-                (dolist (source-id source-ids)
-                  (supertag-services-embed-refresh-block source-id))))))))))
+                ;;(message "DEBUG-EMBED: Found %d source-ids: %S" (length source-ids) source-ids)
+                (when source-ids
+                  ;;(message "DEBUG-EMBED: Refreshing %d embed blocks in %s" (length source-ids) (buffer-name))
+                  (dolist (source-id source-ids)
+                    ;;(message "DEBUG-EMBED: Refreshing block for source-id: %s" source-id)
+                    (supertag-services-embed-refresh-block source-id)))))))))))
 
 ;;; --- System Integration ---
 


### PR DESCRIPTION
- Add inhibit-modification-hooks to after-save-hook functions to prevent conflicts with org-indent-mode in Doom Emacs
- Disable org-mode-hook in temporary buffers to avoid triggering unwanted initialization during parsing
- Fix supertag--generate-org-content to respect supertag-tag-style config instead of hardcoding :tag: format
- Implement supertag-ops-embed-find-by-source-file to enable proper bidirectional sync between source files and embed blocks
- Update embed block rendering to only sync content, preserving headlines and properties in source files
- Add title display in embed block headers: #+begin_embed: ID [Title]

Fixes tab-width warning issue reported in #issue-number