### PR TITLE
fix(ops-tag): ensure persistence when tag already exists in node

### DIFF
--- a/supertag-ops-tag.el
+++ b/supertag-ops-tag.el
@@ -182,20 +182,24 @@ Returns t if the relationship was created or already exists, nil otherwise."
     ;; 2. If tag exists, create the relationship and update node.
     (if-let ((raw-tag (supertag-tag-get tag-id)))
         (let ((tag (supertag--ensure-plist raw-tag))) ; Ensure we have a plist
-          (progn
-            ;; Update the node's :tags property to trigger index update
-            (let ((node (supertag-node-get node-id)))
-              (when node
-                (let ((current-tags (or (plist-get node :tags) '())))
-                  (unless (member tag-id current-tags)
-                    ;; Add tag to node's tags list
-                    (let ((updated-node (plist-put node :tags (cons tag-id current-tags))))
-                      (supertag-store-direct-set :nodes node-id updated-node))))))
-            
-            ;; Avoid creating duplicate relations
-            (unless (supertag-relation-find-between node-id (plist-get tag :id) :node-tag)
-              (supertag-relation-create `(:type :node-tag :from ,node-id :to ,(plist-get tag :id))))
-            t))
+          ;; Update the node's :tags property to trigger index update
+          (let ((node (supertag-node-get node-id)))
+            (when node
+              (let ((current-tags (or (plist-get node :tags) '())))
+                (if (member tag-id current-tags)
+                    ;; CRITICAL FIX: Even if tag exists, we must ensure the node
+                    ;; is marked as modified to trigger persistence events.
+                    ;; Update the :modified-at timestamp to ensure store change event.
+                    (let ((updated-node (plist-put node :modified-at (current-time))))
+                      (supertag-store-direct-set :nodes node-id updated-node))
+                  ;; Add tag to node's tags list
+                  (let ((updated-node (plist-put node :tags (cons tag-id current-tags))))
+                    (supertag-store-direct-set :nodes node-id updated-node))))))
+          
+          ;; Avoid creating duplicate relations
+          (unless (supertag-relation-find-between node-id (plist-get tag :id) :node-tag)
+            (supertag-relation-create `(:type :node-tag :from ,node-id :to ,(plist-get tag :id))))
+          t)
       nil)))
 
 ;; 3.2 Field Operations

--- a/supertag-ui-completion.el
+++ b/supertag-ui-completion.el
@@ -222,8 +222,9 @@
           (when (fboundp 'supertag-node-sync-at-point)
             (supertag-node-sync-at-point)))
         (when (fboundp 'supertag-ops-add-tag-to-node)
-          (supertag-ops-add-tag-to-node node-id candidate :create-if-needed t)
-          (message "Tag '%s' added to node %s" candidate node-id))
+          (let ((result (supertag-ops-add-tag-to-node node-id candidate :create-if-needed t)))
+            (when result
+              (message "Tag '%s' added to node %s" candidate node-id))))
         ;; Add space after tag for better UX
         (unless (looking-at-p "\\s-")
           (insert " "))


### PR DESCRIPTION
When completing a tag that already exists in the node's :tags list (e.g., from text parsing during node sync), the operation would skip the node update, preventing store change events and data persistence.

This fix ensures that even when a tag is already present, the node's :modified-at timestamp is updated to trigger the persistence chain: store update → :store-changed event → dirty flag → scheduled save.

Changes:
- supertag-ops-tag.el: Update node timestamp when tag exists
- supertag-ui-completion.el: Simplify completion exit handler
- supertag-core-persistence.el: Clean up persistence logging

Fixes issue where Tag added message appears but data is not saved to database, causing tags to disappear from view-node display.