### PR TITLE
feat: unify node/table views and normalize reference handling

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,42 @@
 * Changelog
+* [5.1.5] - 2025-11-15
+** Improvements
+*** Node View ergonomics and safety
+- Auto-focus: When switching to the Node View window, the cursor automatically jumps to the value column of the first Field, reducing extra movement.
+- Keybindings restored: j/k, n/p, and page navigation keys now use their defaults, and no longer force-align to the value column when moving.
+- More robust context detection: Only calls Org API inside Org buffers, avoiding errors like “Point must be at an Org heading.”
+- Docstring corrections: Removed unescaped quotes that could cause void-variable errors, preventing `Point` from being parsed as a variable.
+- Non-destructive cleanup: Rendering no longer incorrectly deletes :node-tag relations; if a tag is unavailable, a “Not found (skipped cleanup)” message is shown instead.
+*** Node/Table View unification and reference management
+- Unified reference creation entry point: `supertag-add-reference`, the `:node-reference` field in Node View, the `:node-reference` field in Table View, and sync-layer `:ref-to` parsing now all use `supertag-relation-add-reference` to create `:reference` relationships and automatically insert/deduplicate backlinks.
+- Shared data layer between Node View and Table View: Added `supertag-view-build-node-state` to construct a node's general view state (fields, references, etc.) for use by different layouts.
+- New `node-detail` layout in View Table: `supertag-view-table--build-node-detail-state` + `supertag-view-table--render-node-detail` now support rendering a single node card view through the table engine.
+- Node View rendering prefers delegating to the View Table’s `node-detail` layout; if View Table is not loaded, safely falls back to a local renderer, achieving the structure where "view-node depends on view-table, and view-table only optionally enhances view-node."
+*** Node reference field display improvements
+- In Node View, `:node-reference` fields now show the referenced node’s title(s) instead of just raw IDs (multiple references are comma-separated).
+- When the node-reference value is empty, shows a gray italic “[Empty]” prompt, consistent with other fields.
+*** References section is more readable and clickable
+- Each line uses text properties to bind RET/mouse click to jump to the corresponding node, implementing reference lists that “look like plain text but act like links.”
+
+** Data Integrity
+*** When cleaning tags, also clear field values (globally consistent)
+- When a node has a tag removed, automatically clears all field values under that tag on the node, preventing “old values” from being revived and re-triggering automations.
+- Changes: Field cleanup is now always done inside `supertag-node-remove-tag`; the `supertag-change-tag-at-point` path also does field cleanup (redundantly but safely).
+
+** Reliability
+*** Fixed recursive require error caused by cyclic dependency
+- Resolved: “Recursive ‘require’ for feature ‘supertag-core-scan’” error:
+  - Removed hard dependency of ops-node on ops-field, replaced with forward declaration, and read field definitions directly from the :tags set.
+  - Before calling field deletion, checks `fboundp` to avoid cycles due to load order.
+
+** Automation
+*** Add-tag insertion location returns to "append at end of line"
+- Automated add-tag actions revert to the original behavior: if the headline does not contain the tag, append ` #tag` to the end of the line and save.
+- Dropped use of view-helper’s "intelligent" insertion location logic to avoid experience differences.
+
+**** Implementation Notes
+- Files touched: `supertag-view-node.el`, `supertag-ops-node.el`, `supertag-ui-commands.el`, `supertag-automation.el`。
+- Added window focus hook: enabled on Emacs versions that support `window-selection-change-functions`, with graceful fallback on others.
 * [5.1.4] - 2025-11-11
 ** Improvements
 *** Enhanced Node View with Popup Interface and Evil Mode Support
@@ -824,4 +862,3 @@ maintaining control through customization options.
 - Enhanced query system with history management
 - Improved code organization and modularity
 - Enhanced documentation and examples
-

--- a/org-supertag.el
+++ b/org-supertag.el
@@ -148,12 +148,18 @@ This function loads all necessary components and sets up the environment."
     
     ;; Step 11: Enable completion globally
     (global-supertag-ui-completion-mode 1)
-    
+
     ;; Step 12: Enable completion in already-open org buffers
     (dolist (buffer (buffer-list))
       (with-current-buffer buffer
         (when (derived-mode-p 'org-mode)
           (supertag-ui-completion-mode 1)))))
+
+  ;; Optionally auto-show Node View side window and follow context
+  (when (and (boundp 'supertag-view-node-auto-show)
+             supertag-view-node-auto-show
+             (fboundp 'supertag-view-node-ensure-shown))
+    (supertag-view-node-ensure-shown))
 
 (defun supertag--check-critical-config ()
   "Check critical configuration before initialization.

--- a/supertag-automation.el
+++ b/supertag-automation.el
@@ -646,7 +646,8 @@ PARAMS should contain :state with the new TODO keyword (e.g., \"DONE\")."
 
 (defun supertag-automation-action-add-tag (node-id params)
   "Add a tag to the node.
-Uses the same data-first approach as UI commands for consistency."
+Restore original behavior: append inline #tag at end of headline line
+if not already present."
   (require 'supertag-ops-tag)
   (require 'supertag-view-helper)
   (when (and node-id)
@@ -655,13 +656,13 @@ Uses the same data-first approach as UI commands for consistency."
              (tags (plist-get node :tags)))
         (if (member tag-name tags)
             (message "SKIP(add-tag): tag '%s' already on node %s" tag-name node-id)
-          ;; 1. Update database first (same as UI command)
+          ;; 1) Update datastore first
           (supertag-ops-add-tag-to-node node-id tag-name :create-if-needed t)
-          ;; 2. Update file text
+          ;; 2) Update buffer text: end-of-line append if missing
           (supertag-service-org--with-node-buffer node-id
             (lambda ()
-              ;; Check if tag already exists in the line to avoid duplicates
-              (let ((line-content (buffer-substring (line-beginning-position) (line-end-position))))
+              (let ((line-content (buffer-substring (line-beginning-position)
+                                                    (line-end-position))))
                 (unless (string-match (concat "#" (regexp-quote tag-name) "\\b") line-content)
                   (end-of-line)
                   (insert (concat " #" tag-name))))

--- a/supertag-core-persistence.el
+++ b/supertag-core-persistence.el
@@ -572,7 +572,9 @@ Returns Emacs standard time format (high low micro pico)."
   "Safe time comparison function.
 TIME1 and TIME2 should be in Emacs time format.
 Returns t if times are equal, otherwise returns nil."
-  (and (timep time1) (timep time2) (equal time1 time2)))
+  (and (supertag--validate-time time1)
+       (supertag--validate-time time2)
+       (equal time1 time2)))
 
 (defun supertag--validate-time (time-value)
   "Validate that the time value is in valid Emacs time format.


### PR DESCRIPTION
  - Auto-focus cursor to first field value in Node View; restore default navigation keys and guard Org-specific calls to Org buffers only.
  - Remove destructive cleanup in Node View rendering and fix docstrings that caused Point void-variable errors.
  - Centralize :reference creation via supertag-relation-add-reference across UI, Node View, Table View, and sync :ref-to, with automatic backlink creation/deduplication.
  - Introduce shared node state builder supertag-view-build-node-state and a node-detail layout in View Table, then make Node View rendering delegate to this layout (with safe local fallback).
  - Improve :node-reference field display to show referenced node titles (or [Empty]), and keep the References section as plain-text-but-clickable links.
  - Ensure removing a tag clears its field values on the node, fix recursive require 'supertag-core-scan' by loosening ops-node/ops-field coupling, and revert automation add-tag insertion to simple end-of- line append.