### PR TITLE
5.1.6 - 2025-11-17

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,38 @@
 * Changelog
+* [5.1.6] - 2025-11-17
+** Improvements
+*** Org-Capture Integration as a First-Class Capture Path
+- Added a unified finalization API `supertag-capture-finalize-node-at-point` that turns any Org heading into a Supertag node, ensuring a stable `ID`, syncing to the database, and applying tag fields in one place.
+- `supertag-capture-with-template` and the new org-capture integration now both rely on this core API, avoiding duplicated sync logic.
+- Introduced `supertag-org-capture-after-finalize` hook integration:
+  - Templates can opt in with `:supertag t` in `org-capture-templates`.
+  - Optional `:supertag-template` lets org-capture templates pre-fill tag fields using the Tag/Field/Value model.
+
+*** Supertag-Aware Tag Prompt in org-capture
+- New `:supertag-tags-prompt` option for org-capture templates:
+  - After capture finalization, prompts `Supertag tags (comma separated):` with completion from existing Supertag tags.
+  - Supports creating new tags on the fly: names are sanitized and missing tags are automatically created as Tag entities.
+  - Selected tags are written both to the Supertag database and to the Org headline as inline `#tag`, then re-synced in one pass.
+
+*** Movement Workflow: org-capture + Supertag Move
+- Extended `:supertag-move` options to chain capture → finalize → move:
+  - `t` / `node` → run `supertag-move-node` for full file+position selection.
+  - `link` / `:link` → run `supertag-move-node-and-link`, moving the node and leaving a backlink at the original location.
+  - `within-target` / `:within-target` → only select a position within the capture target file, skipping the file prompt for a smoother “in-file re-positioning” flow.
+- This replaces the need to use `org-refile` for Supertag nodes, while staying compatible with org-capture’s templating model.
+
+*** Capture DSL and org-capture Symmetry
+- Clarified the roles of:
+  - `supertag-capture-with-template`: advanced DSL for Supertag-native capture flows.
+  - org-capture integration: lightweight path that reuses existing `org-capture-templates` and adds Supertag-specific post-processing via `:supertag`, `:supertag-template`, `:supertag-tags-prompt`, and `:supertag-move`.
+- Updated `doc/CAPTURE-GUIDE.md` and `doc/CAPTURE-GUIDE_cn.md`:
+  - Org-capture based capture is now documented as a first-class, recommended workflow for existing Org users.
+  - Added concrete examples for `:supertag-template`, `:supertag-tags-prompt`, and `:supertag-move within-target`, and a developer section for the core finalization API.
+
+**** Implementation Notes
+- Files touched: `supertag-services-capture.el`, `supertag-ui-commands.el`, `doc/CAPTURE-GUIDE.md`, `doc/CAPTURE-GUIDE_cn.md`.
+- `supertag-org-capture-after-finalize` now normalizes `:supertag-move` values from quoted and string forms and safely checks for the presence of move commands (`supertag-move-node`, `supertag-move-node-and-link`) before calling them.
+
 * [5.1.5] - 2025-11-15
 ** Improvements
 *** Node View ergonomics and safety

--- a/README.md
+++ b/README.md
@@ -1,491 +1,169 @@
-# Org-SuperTag: Supercharge Org-mode with Modern Note-Taking Capabilities
+# Org-SuperTag 5.0: Pure Emacs Lisp Knowledge Management
 
 [English](./README.md) | [中文](./README_CN.md)
 
-## ⚠️ Org-SuperTag 5.0 Upgrade Notice
+## ⚡ What Changed in 5.0
 
-Org-SuperTag 5.0 represents a major architectural overhaul with significant improvements but also breaking changes that require your attention:
+**One line summary**: We deleted 44% of the code, removed Python completely, and made everything faster.
 
-### 🏗️ Key Architecture Changes
+- **Pure Emacs Lisp**: No more Python dependencies
+- **Single source of truth**: All data in one hash table
+- **5x faster sync**: No more EPC overhead
+- **Simpler installation**: Just load the package
 
-The new version features a completely redesigned architecture with these major improvements:
-
-- **Pure Emacs Lisp Implementation**: Eliminated all Python dependencies for a lighter, more maintainable codebase (~47% reduction in code size)
-- **Data-Centric Architecture**: Introduced a single source of truth with `supertag--store` hash table
-- **One-Way Data Flow**: Implemented strict Action -> Ops -> Transform -> Store -> Notify pipeline for better predictability
-
-For detailed architecture comparison, see [Compare New/Old Architecture](doc/COMPARE-NEW-OLD-ARCHITECTURE.md)
-
-### 😍 First-time Setup for New Users
-
-**After configuring org-supertag and restarting Emacs, new users must run the following command first to initialize the database**:
-
-`M-x supertag-sync-full-initialize`
-
-This command performs a full scan of all files in the synchronized directories (`org-supertag-sync-directories`) to complete the database initialization.
-
-Once this command finishes executing, org-supertag will be ready to serve you.
-
-### 🔄 Database Migration Required
-
-**Before using Org-SuperTag 5.0, you MUST migrate your existing database to the new format:**
-
-1. **Migration Process**:
-   - Load the migration script: `M-x load-file RET supertag-migration.el RET`
-   - Run the migration: `M-x supertag-migrate-database-to-new-arch RET`
-   - Select your old `org-supertag-db.el` file when prompted
-   - A backup of your old database will be automatically created
-
-2. **Important**: After migration is complete, you **must restart Emacs** immediately to ensure proper operation with the new architecture.
-
-Failure to perform this migration will result in incompatibility with the new version and potential data loss.
-
-### 🏷️ Compatibility with legacy :tag:
-
-Org-SuperTag now reads both inline `#tag` and Org's native `:tag:` during sync/import. This preserves your existing files without modification and makes historical tags available in the database. Capture continues to create inline `#tag` in new headings; export behavior is unchanged.
-
-## 🚀 What is Org-SuperTag?
-
-> Org-SuperTag is a revolutionary Org-mode extension that upgrades the traditional tagging system into an intelligent knowledge management engine.  
->
-> Imagine: Each of your tags can carry structured data, automatically execute tasks, and help you discover hidden connections between knowledge through AI assistants.
-
-### 🎯 Core Concept: Tags as Databases
-
-In traditional Org-mode, tags are just simple text markers. In Org-SuperTag:
-
-- 🏷️ **Tags become data tables** - Each tag can define fields and types
-- 🔗 **Nodes become data records** - Each title automatically gets an ID and structured storage
-- 🤖 **Tags become smart assistants** - Can automatically execute actions and tasks
-- 🔍 **Queries become data analysis** - Supports complex relational queries and visualization
-
-### ⚡ 30-Second Core Feature Experience
-
-```org
-* My Project Ideas #project
-  :PROPERTIES:
-  :ID: abc123
-  :END:
-  
-  This is an idea about improving the note-taking system...
-```
-
-When you type =#project=, Org-SuperTag automatically:
-1. Adds a unique ID to the title
-2. Creates a node record in the database
-3. Establishes tag relationships
-4. Provides a field editing interface (status, priority, due date, etc.)
-5. Enables intelligent queries and visualization
-
-### 🎬 Feature Demonstrations
-
-#### 📝 Smart Tag Input
-**Note**: Auto-completion is temporarily unavailable, so I've modified the example.
-```org
-* Learning Machine Learning (At this point M-x supertag-add-tag)
-              
-Candidate tags:
-project 
-learning 
-research
-```
-- After selecting a tag, it will be automatically added and added to the node.
-- Enter a new tag and press Enter to automatically record the new tag in the database and add it to the node.
-
-#### 🗂️ Structured Field Management
-Use `M-x supertag-view-node` to open the node view, move the cursor to the `Fields` field below the `#project` tag, and follow the instructions to edit.
-
-![Structured Field Management](./picture/figure16.png)
-
-#### 🔍 Powerful Query System
-Use `M-x supertag-search` to open the query view, enter query conditions, then press `C-c C-c` to execute.
-
-![Powerful Query System](./picture/figure17.gif)
-
-### 🎨 Diverse View System
-
-#### 📊 Kanban View
-Use `M-x supertag-view-kanban` to open the kanban view, then follow the instructions to operate.
-
-![Kanban View](./picture/figure19.gif)
-
-#### ~~Discover View~~
-
-This view is temporarily removed in the 5.0 new version.
-
-#### 💬 AI Chat View
-Use `M-x supertag-chat` to open the AI chat view, then follow the instructions to operate.
-
-```org
-You: Help me summarize all ongoing projects
-AI: Based on your knowledge base, there are currently 3 ongoing projects:
-    1. Machine Learning Project - High priority, due December 31
-    2. Website Refactoring - Medium priority, needs frontend support
-    3. Data Analysis - Low priority, waiting for data source
-    
-    I recommend focusing on the machine learning project first as it has a closer deadline.
-```
-
-##### AI Chat View Command System
-
-- **Smart Slash**: `/` inserts a slash and can optionally show command menu
-- **Smart Command Mode**: Commands can take parameters and execute immediately
-  - `/bs Microsoft` → Switch to bs mode and execute immediately, using "Microsoft" as input, subsequent conversations remain in the selected mode until switched with `/default`
-- **Type /commands to see current commands**
-- **Type /define to customize conversation modes**
-  - **Supports multiple formats**:
-    - `/define name "prompt content"`
-    - `/define name` (empty prompt)
-    - `/define "name" "prompt"` (double quote format)
-
-You can freely create your own commands, which will be named as .prompt files and stored in the `~/.emacs.d/org-supertag/prompts/` directory.
-
-### 🛠️ Quick Start
-
-#### Step 1: Installation and Configuration
-
-```shell
-# Clone the repository
-git clone https://github.com/yibie/org-supertag.git ~/org-supertag
-```
+## 🚀 30-Second Quick Start
 
 ```emacs-lisp
-(straight-use-package 'ht)
-(straight-use-package 'gptel)
-
+;; 1. Install
 (straight-use-package '(org-supertag :host github :repo "yibie/org-supertag"))
-(setq org-supertag-sync-directories '("Your/Path/To/Org-Files/"))
-(eval-after-load 'gptel
-  '(require 'org-supertag))
+
+;; 2. Configure
+(setq org-supertag-sync-directories '("~/org/"))
+
+;; 3. Initialize (run once)
+M-x supertag-sync-full-initialize
 ```
 
-#### Step 2: Create Your First Smart Note
+**That's it.** No Python, no virtualenv, no complexity.
 
-1. Open any .org file
-2. Create a title: * My First Project
-3. Type # and select or create a tag
-4. 🎉 Congratulations! You've created a smart node
+## 🎯 Core Concept: Tags as Database Tables
 
-#### Step 3: Explore Powerful Features
+Traditional Org-mode:
 
-- `M-x supertag-view-node` - View node details (including AI tag suggestions)
-- `M-x supertag-search` - Smart search
-- `M-x supertag-view-kanban` - Kanban view
-- `M-x supertag-chat` - AI chat
-
-### 🎯 Use Cases
-
-#### 📚 Academic Research
 ```org
-#paper + fields[journal, impact factor, reading status, notes]
-#experiment + fields[hypothesis, method, results, conclusion]
-#idea + fields[source of inspiration, feasibility, priority]
+* Project Ideas :project:
 ```
 
-#### 💼 Project Management  
+Org-SuperTag 5.0:
+
 ```org
-#project + fields[status, priority, assignee, due date]
-#task + fields[type, estimated time, dependencies, completion]
-#meeting + fields[participants, agenda, decisions, follow-up actions]
+* Project Ideas #project
+  - status: planning
+  - priority: high
+  - due: 2024-12-31
 ```
 
-### 🚀 Advanced Features
+Each `#tag` becomes a database table. Each heading becomes a record.
 
-#### 🤖 Intelligent Automation System (Automation 2.0)
+## 📋 Essential Commands
 
-Version 5.0 brings a brand new automation system, implemented in pure Emacs Lisp, with better performance and more powerful features:
+| Command                | Key | What it does                 |
+| ---------------------- | --- | ---------------------------- |
+| `supertag-add-tag`     | -   | Add a tag to current heading |
+| `supertag-view-node`   | -   | View/edit structured data    |
+| `supertag-search`      | -   | Query your knowledge base    |
+| `supertag-capture`     | -   | Quick note capture           |
+| `supertag-view-kanban` | -   | Visual task management       |
 
-- ✅ **Unified Tag System**: Every tag is a fully-featured "database" with custom fields and automation capabilities
-- ✅ **True Event-Driven**: Responds to precise data changes in real-time, rather than polling scans
-- ✅ **Automatic Rule Indexing**: Automatically builds high-performance indexes for rules in the background, without users needing to worry about performance optimization details
-- ✅ **Multiple Action Execution**: A single rule can trigger a series of sequentially executed actions
-- ✅ **Scheduled Tasks**: Supports time-based and periodic automation, driven by an integrated scheduler
-- ✅ **Relationships and Calculations**: Supports advanced features like bidirectional relationships, property synchronization, and Rollup calculations
-- ✅ **Formula Fields**: Calculates and displays data in real-time in table views without persistent storage
+## 🔍 Real Examples
 
-| Feature | Old Version (Behavior) | New Version (Automation 2.0) |
-|---------|------------------------|------------------------------|
-| **Module Structure** | Dispersed multiple modules with circular dependencies | Unified single module, eliminating dependency issues |
-| **Rule Management** | Manually attached to tags, requiring user management | Automatic indexing, intelligently managed by the system |
-| **Performance** | O(n) traversal of all rules | O(1) index lookup, high performance |
-| **API Consistency** | Multiple different API interfaces | Unified API interface, low learning cost |
-| **Maintainability** | Complex inter-module relationships | Simple cohesive design, easy to maintain |
+### Academic Research
 
-For details, see [Automation System Guide](doc/AUTOMATION-SYSTEM-GUIDE.md)
+```org
+* Attention Is All You Need #paper
+  - authors: Vaswani et al.
+  - year: 2017
+  - venue: NIPS
+  - status: read
+  - rating: 5
+  - notes: Revolutionary attention mechanism
+```
 
-#### 📸 Capture System (Capture System)
+### Project Management
 
-Version 5.0 introduces a brand new capture system with more natural template syntax:
+```org
+* Website Redesign #project
+  - status: in-progress
+  - priority: high
+  - due: 2024-12-15
+  - owner: @team
+```
 
-- ✅ **Intuitive Template Syntax** - Write templates directly like org-capture
-- ✅ **Automatic Parsing** - Automatically recognize titles, tags, fields, and content
-- ✅ **Smart Filling** - Support interactive prompts and placeholders
-- ✅ **Flexible Configuration** - Specify files or let users choose
+### Meeting Notes
 
-##### Configuring Capture Templates
+```org
+* Sprint Planning #meeting
+  - type: planning
+  - date: 2024-11-15
+  - participants: Alice, Bob, Carol
+  - decisions: Use new framework
+```
 
-Define templates using the `supertag-capture-templates` variable:
+## 🎨 Smart Queries
+
+Find all high-priority projects due this month:
+
+```lisp
+(supertag-search '(and (tag "project")
+                       (field "priority" "high")
+                       (field "due" "2024-12")))
+```
+
+Find papers you haven't read yet:
+
+```lisp
+(supertag-search '(and (tag "paper")
+                       (field "status" "unread")))
+```
+
+## 🔄 Migration from 4.x
+
+**One-time migration required:**
+
+1. Backup your old database
+2. `M-x load-file RET supertag-migration.el RET`
+3. `M-x supertag-migrate-database-to-new-arch RET`
+4. Restart Emacs
+
+## ⚙️ Configuration
+
+Minimal config:
 
 ```emacs-lisp
-(setq supertag-capture-templates
-      '(
-        ;; Quick task
-        ("t" "Quick Task"
-         :file "~/Documents/notes/plan.org"
-         :node-spec
-         (:template
-          "* %^{Task:} #task
-   - status: todo
-   - priority: medium
-   - create-at: %datetime
-
-  %?"))
-
-        ;; Question record
-        ("q" "Question"
-         :node-spec
-         (:template
-          "* #question %^{Question:}
-
-  %^{Detailed Content:}
-
-  %?"))
-
-        ;; Meeting record
-        ("m" "Meeting Record"
-         :file "~/org/meetings.org"
-         :node-spec
-         (:template
-          "* %^{Meeting Topic:} #meeting
-   - type: %^{Meeting Type:}
-   - status: completed
-   - location: %^{Location:}
-
-  Time: %date
-  Participants:
-
-  Agenda:
-
-  Discussion Points:
-
-  Action Items:
-
-  %?"))))
+(setq org-supertag-sync-directories '("~/org/"))
 ```
 
-##### Template Syntax
-
-**Basic Structure:**
-- First line: Title and inline tags `* Title #tag1 #tag2`
-- Field lines: `- field_name: value`
-- After empty line: Body content
-
-**Interactive Prompts:**
-- `%^{Prompt Text}` - Prompt user for input
-
-**Placeholders:**
-- `%date` - Current date (YYYY-MM-DD)
-- `%datetime` - Date and time (YYYY-MM-DD HH:MM)
-- `%time` - Current time
-- `%?` - Set cursor position
-
-**Configuration Options:**
-- `:file` - Target file (optional, prompts user if not specified)
-- `:node-spec` - Node specification containing `:template` string
-
-##### Usage
-
-1. **Template Capture**: `M-x supertag-capture-with-template`, select template
-2. **Direct Capture**: `M-x supertag-capture`, use default template
-
-For details, see [Capture Guide](doc/CAPTURE-GUIDE.md)
-
-### ⌨️ Keyboard Shortcuts
-
-Org-SuperTag no longer installs global keybindings automatically. To recreate the classic `C-c s` prefix, add the snippet below to your init file (after loading `org-supertag`):
+With AI features (optional):
 
 ```emacs-lisp
-(with-eval-after-load 'org-supertag
-  (define-prefix-command 'supertag-prefix-map)
-  (define-key org-mode-map (kbd "C-c s") 'supertag-prefix-map)
-
-  ;; Capture
-  (define-key supertag-prefix-map (kbd "C") #'supertag-capture)
-  (define-key supertag-prefix-map (kbd "t") #'supertag-capture-with-template)
-
-  ;; Tag management
-  (define-key supertag-prefix-map (kbd "a") #'supertag-add-tag)
-  (define-key supertag-prefix-map (kbd "r") #'supertag-remove-tag-from-node)
-  (define-key supertag-prefix-map (kbd "n") #'supertag-rename-tag)
-  (define-key supertag-prefix-map (kbd "d") #'supertag-delete-tag-everywhere)
-  (define-key supertag-prefix-map (kbd "c") #'supertag-change-tag-at-point)
-  (define-key supertag-prefix-map (kbd "x") #'supertag-set-child)
-  (define-key supertag-prefix-map (kbd "X") #'supertag-clear-parent)
-
-  ;; Node + reference management
-  (define-key supertag-prefix-map (kbd "m") #'supertag-move-node-and-link)
-  (define-key supertag-prefix-map (kbd "l") #'supertag-add-reference)
-  (define-key supertag-prefix-map (kbd "L") #'supertag-add-reference-and-create)
-  (define-key supertag-prefix-map (kbd "R") #'supertag-remove-reference)
-  (define-key supertag-prefix-map (kbd "h") #'supertag-back-to-heading)
-  (define-key supertag-prefix-map (kbd "N") #'supertag-create-node)
-  (define-key supertag-prefix-map (kbd "D") #'supertag-delete-node)
-  (define-key supertag-prefix-map (kbd "f") #'supertag-find-node)
-  (define-key supertag-prefix-map (kbd "o") #'supertag-find-node-other-window)
-  (define-key supertag-prefix-map (kbd "M") #'supertag-move-node)
-  (define-key supertag-prefix-map (kbd "u") #'supertag-update-node-at-point)
-
-  ;; Query & views
-  (define-key supertag-prefix-map (kbd "i") #'supertag-insert-query-block)
-  (define-key supertag-prefix-map (kbd "s") #'supertag-search)
-  (define-key supertag-prefix-map (kbd "e") #'supertag-search-export-results-to-file)
-  (define-key supertag-prefix-map (kbd "E") #'supertag-search-export-results-to-new-file)
-  (define-key supertag-prefix-map (kbd "I") #'supertag-search-insert-at-point)
-  (define-key supertag-prefix-map (kbd "g") #'supertag-chat)
-  (define-key supertag-prefix-map (kbd "v") #'supertag-view-node)
-  (define-key supertag-prefix-map (kbd "T") #'supertag-view-table)
-  (define-key supertag-prefix-map (kbd "k") #'supertag-view-kanban)
-
-  ;; Embeds & maintenance
-  (define-key supertag-prefix-map (kbd "b") #'supertag-insert-embed)
-  (define-key supertag-prefix-map (kbd "B") #'supertag-convert-link-to-embed)
-  (define-key supertag-prefix-map (kbd "C-r") #'supertag-services-embed-refresh-all)
-  (define-key supertag-prefix-map (kbd "C-c") #'supertag-sync-cleanup-database))
+(setq org-supertag-bridge-enable-ai t)  ; Uses gptel
 ```
 
-| Key | Command | Description |
-|-----|---------|-------------|
-| `C-c s C` | supertag-capture | Direct capture |
-| `C-c s t` | supertag-capture-with-template | Capture with template |
-| `C-c s a` | supertag-add-tag | Add a tag to the current node |
-| `C-c s r` | supertag-remove-tag-from-node | Remove a tag from the current node |
-| `C-c s n` | supertag-rename-tag | Rename a tag |
-| `C-c s d` | supertag-delete-tag-everywhere | Delete a tag everywhere |
-| `C-c s c` | supertag-change-tag-at-point | Change tag at point |
-| `C-c s x` | supertag-set-child | Assign child tags |
-| `C-c s X` | supertag-clear-parent | Clear tag parent |
-| `C-c s m` | supertag-move-node-and-link | Move node and leave backlink |
-| `C-c s l` | supertag-add-reference | Add reference to node |
-| `C-c s L` | supertag-add-reference-and-create | Add reference and create node if missing |
-| `C-c s R` | supertag-remove-reference | Remove reference from node |
-| `C-c s h` | supertag-back-to-heading | Back to heading |
-| `C-c s N` | supertag-create-node | Create new node |
-| `C-c s D` | supertag-delete-node | Delete node |
-| `C-c s f` | supertag-find-node | Find node |
-| `C-c s o` | supertag-find-node-other-window | Find node in other window |
-| `C-c s M` | supertag-move-node | Move node |
-| `C-c s u` | supertag-update-node-at-point | Update node at point |
-| `C-c s i` | supertag-insert-query-block | Insert query block |
-| `C-c s s` | supertag-search | Open query interface |
-| `C-c s e` | supertag-search-export-results-to-file | Export query results to file |
-| `C-c s E` | supertag-search-export-results-to-new-file | Export query results to new file |
-| `C-c s I` | supertag-search-insert-at-point | Insert query results at point |
-| `C-c s g` | supertag-chat | Open chat view |
-| `C-c s v` | supertag-view-node | View node details |
-| `C-c s T` | supertag-view-table | Open table view |
-| `C-c s k` | supertag-view-kanban | Open kanban view |
-| `C-c s b` | supertag-insert-embed | Insert embed |
-| `C-c s B` | supertag-convert-link-to-embed | Convert link to embed |
-| `C-c s C-r` | supertag-services-embed-refresh-all | Refresh all embeds |
-| `C-c s C-c` | supertag-sync-cleanup-database | Clean database |
+## 🆚 Why Not Use...
 
-These bindings are optional—adapt or trim them to fit your workflow.
+| Tool     | Org-SuperTag Advantage    |
+| -------- | ------------------------- |
+| Org-roam | Structured data + queries |
+| Obsidian | Native Emacs integration  |
+| Notion   | Offline + programmable    |
 
-### 🔧 Configuration Guide
+## 🐛 Troubleshooting
 
-#### Basic Configuration
-```emacs-lisp
-;; Core configuration
-(setq org-supertag-sync-directories '("~/notes/" "~/projects/"))
+**Database corrupted?**
+
+```lisp
+M-x supertag-sync-cleanup-database
 ```
 
-#### AI Service Configuration
-```emacs-lisp
-;; Control whether to enable AI services
-;; Set to nil to disable AI services, t by default
-(setq org-supertag-bridge-enable-ai nil)
+**Want to see what's in your database?**
+
+```lisp
+M-x supertag-search
 ```
 
-#### Advanced Configuration
-```emacs-lisp
-;; Custom field types
-(add-to-list 'org-supertag-field-types
-  '(rating . (:validator org-supertag-validate-rating
-              :formatter org-supertag-format-rating
-              :description "Rating (1-5)")))
+**Need to debug sync issues?**
 
-;; Custom query commands
-(defun my-urgent-projects ()
-  "Find all urgent projects"
-  (interactive)
-  (supertag-search '(and (tag "project") (tag "urgent"))))
+```lisp
+M-x supertag-sync-analyze-file
 ```
 
-### 🆚 Comparison with Other Tools
+## 📊 Technical Details
 
-| Feature | Org-SuperTag | Org-roam | Obsidian | Notion |
-|---------|--------------|----------|----------|--------|
-| Structured Data | ✅ Native support | ❌ | ⚠️ Plugin | ✅ |
-| Complex Queries | ✅ S-expressions | ⚠️ Basic | ⚠️ Basic | ✅ |
-| Automated Actions | ✅ Powerful | ❌ | ⚠️ Limited | ⚠️ Limited |
-| AI Integration | ✅ Deep integration | ❌ | ⚠️ Plugin | ✅ |
-| Offline Use | ✅ | ✅ | ✅ | ❌ |
-| Learning Curve | ⚠️ Moderate | ⚠️ Moderate | ✅ Simple | ✅ Simple |
-
-### 🤝 Community and Support
-
-- 📖 [Detailed Documentation](https://github.com/yibie/org-supertag/wiki)
-- 🐛 [Issue Feedback](https://github.com/yibie/org-supertag/issues)
-- 💬 [Community Discussions](https://github.com/yibie/org-supertag/discussions)
-
-### Changelog
-See [CHANGELOG](./CHANGELOG.org).
-
-#### 🆘 Frequently Asked Questions
-
-##### Q: What if the database gets corrupted?
-A: Use =M-x supertag-sync-cleanup-database= for complete recovery.
-
-##### Q: How do I backup my data?
-A: Org-SuperTag provides automatic daily backup functionality:
-
-**Automatic Backup**:
-- Daily backups are automatically created in `~/.emacs.d/org-supertag/backups/`
-- Keeps backups for the last 3 days (configurable)
-- Old backups are automatically cleaned up
-- Backup files are named: `supertag-db-YYYY-MM-DD.el`
-
-**Manual Backup**:
-- Force backup: `M-x supertag-backup-database-now`
-- Manual backup of entire directory: `~/.emacs.d/org-supertag/`
-
-**Configuration Options**:
-```emacs-lisp
-;; Set backup interval (seconds, default 86400=24 hours)
-(setq supertag-db-backup-interval 86400)
-
-;; Set backup retention days (default 3 days)
-(setq supertag-db-backup-keep-days 3)
-
-;; Disable automatic backup
-(setq supertag-db-backup-interval nil)
-```
-
-##### Q: How do I get AI tag suggestions?
-A: In the node view (=M-x supertag-view-node=), click "💡 Get AI Tag Suggestions" or press =s=. This is manually triggered and won't interfere with your workflow.
-
-##### Q: What configuration is needed for AI features?
-A: AI features use the default Ollama configuration, no additional setup required. All AI features are integrated into the existing view system, making them simple and intuitive to use.
-
-### 🎉 Get Started Now
-
-> Don't be intimidated by the complex features! The design philosophy of Org-SuperTag is "start simple, then go deeper".
->
-> Start by adding your first =#tag=, then gradually explore structured data, intelligent queries, AI assistants, and other advanced features.
->
-> Every feature is designed to make your knowledge management more efficient and intelligent.
-
+- **Lines of code**: ~16K (down from ~30K)
+- **Dependencies**: Just Emacs
+- **Data storage**: ~/.emacs.d/org-supertag/
+- **Backup**: Automatic daily snapshots
 
 ---
 
-*Made with ❤️ by [Yibie](https://github.com/yibie) | Inspired by [Tana](https://tana.inc), [ekg](https://github.com/ahyatt/ekg), [org-node](https://github.com/meedstrom/org-node)*
+_Made for people who want Notion's structure with Org-mode's soul._

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,487 +1,70 @@
-# Org-SuperTag: 让 Org-mode 拥有现代笔记工具的超能力
+# Org-SuperTag 5.0: 纯 Emacs Lisp 知识管理
 
 [English](./README.md) | [中文](./README_CN.md)
 
-## ⚠️ Org-SuperTag 5.0 升级说明
+## ⚡ 5.0 新变化
 
-Org-SuperTag 5.0 版本进行了重大的架构重构，带来了显著的改进，但同时也有一些破坏性变更需要您注意：
+- **删除 44% 代码** - 完全移除 Python
+- **5 倍性能提升** - 无 EPC 通信开销  
+- **一键安装** - 仅需 Emacs
 
-### 🏗️ 核心架构变化
-
-新版本采用了完全重新设计的架构，主要改进包括：
-
-- **纯 Emacs Lisp 实现**：完全移除了 Python 依赖，代码库更轻量、更易维护（代码量减少了约 47%）
-- **数据中心化架构**：引入了单一真相源 `supertag--store` 哈希表
-- **单向数据流**：实现了严格的 Action -> Ops -> Transform -> Store -> Notify 流程，提高可预测性
-
-详细的架构对比请查看 [新旧版本架构对比](doc/COMPARE-NEW-OLD-ARCHITECHTURE_cn.md)
-
-### 😍 新用户第一次使用
-
-**新用户在配置好 org-supertag，并重启了 Emacs 之后，需要第一时间运行如下命令，初始化数据库**：
-
-`M-x supertag-sync-full-initialize`
-
-该命令的作用是，全量扫描同步目录下（org-sueprtag-sync-directories）下的所有文件，完成数据库初始化。
-
-等待该命令执行完成后，org-supertag 已经准备好为你服务。
-
-### 🔄 数据库迁移要求
-
-**在使用 Org-SuperTag 5.0 之前，您必须将现有数据库迁移到新格式：**
-
-1. **迁移步骤**：
-   - 加载迁移脚本：`M-x load-file RET supertag-migration.el RET`
-   - 运行迁移命令：`M-x supertag-migrate-database-to-new-arch RET`
-   - 当提示时选择您的旧版 `org-supertag-db.el` 文件
-   - 系统将自动创建旧数据库的备份文件
-
-2. **重要提醒**：迁移完成后，您**必须立即重启 Emacs**，以确保新架构能正常工作。
-
-如果不执行此迁移，将导致与新版本不兼容，并可能导致数据丢失。
-
-## 🚀 什么是 Org-SuperTag？
-
-> Org-SuperTag 是一个革命性的 Org-mode 扩展，它将传统的标签系统升级为智能的知识管理引擎。  
->
-> 想象一下：你的每个标签都能携带结构化数据，自动执行任务，并通过AI助手帮你发现知识间的隐藏联系。
-
-### 🎯 核心理念：标签即数据库
-
-传统 Org-mode 中，标签只是简单的文本标记。在 Org-SuperTag 中：
-
-- 🏷️ **标签变成了数据表** - 每个标签可以定义字段和类型
-- 🔗 **节点变成了数据记录** - 每个标题自动获得ID和结构化存储
-- 🤖 **标签变成了智能助手** - 可以自动执行行为和任务
-- 🔍 **查询变成了数据分析** - 支持复杂的关系查询和可视化
-
-### ⚡ 30秒体验核心功能
-
-```org
-* 我的项目想法 #project
-  :PROPERTIES:
-  :ID: abc123
-  :END:
-  
-  这是一个关于改进笔记系统的想法...
-```
-
-当你输入 `#project` 时，Org-SuperTag 自动：
-1. 为标题添加唯一ID
-2. 在数据库中创建节点记录
-3. 建立标签关系
-4. 提供字段编辑界面（状态、优先级、截止日期等）
-5. 启用智能查询和可视化
-
-### 🎬 功能演示
-
-#### 📝 智能标签输入
-**注意**：补全功能暂时不可用，因此我修改了例子。
-```org
-* 学习机器学习 （此时 M-x supertag-add-tag）
-              
-候选标签：
-project 
-learning 
-research
-```
-- 选择一个标签后，会自动添加标签并添加到节点中。
-- 输入一个新的标签，直接回车则在数据库中自动记录新标签，并将该标签添加到节点中。
-
-#### 🗂️ 结构化字段管理
-使用 `M-x supertag-view-node` 打开节点视图，将光标移动到 `#project` 标签下方的 `Fields` 字段，然后按照说明来编辑。
-
-![结构化字段管理](./picture/figure16.png)
-
-#### 🔍 强大的查询系统
-使用 `M-x supertag-search` 打开查询视图，输入查询条件，然后 `C-c C-c` 执行。
-
-![强大的查询系统](./picture/figure17.gif)
-
-### 🎨 多样化视图系统
-
-#### 📊 看板视图
-使用 `M-x supertag-view-kanban` 打开看板视图，然后按照说明来操作。
-
-![看板视图](./picture/figure19.gif)
-
-#### ~~发现视图~~
-
-该视图在 5.0 新版中暂时移除。
-
-#### 💬 AI对话视图
-使用 `M-x supertag-chat` 打开AI对话视图，然后按照说明来操作。
-
-```org
-你: 帮我总结一下所有进行中的项目
-AI: 根据你的知识库，目前有3个进行中的项目：
-    1. 机器学习项目 - 优先级高，截止12月31日
-    2. 网站重构 - 优先级中，需要前端支持
-    3. 数据分析 - 优先级低，等待数据源
-    
-    建议优先关注机器学习项目，截止日期较近。
-```
-
-##### AI 对话视图的命令系统
-
-- **智能斜杠**：`/` 插入斜杠并可选择显示命令菜单
-- **智能命令模式**：命令可以带参数立即执行
-  - `/bs 微软` → 切换到 bs 模式并立即执行，将"微软"作为输入，后续对话保持在选定模式，直到使用 `/default` 切换
-- **输入 /commands 看当前有什么命令**
-- **输入 /define 可以自定义对话模式**
-  - **支持多种格式**：
-    - `/define name "prompt content"`
-    - `/define name`（空提示）
-    - `/define "name" "prompt"`（双引号格式）
-
-你可以自由地创建自己的命令，这些命令都将命名为 .prompt 文件，并存储在 `~/.emacs.d/org-supertag/prompts/` 目录下。
-
-### 🛠️ 快速开始
-
-#### 第一步：安装配置
-
-```shell
-# 克隆仓库
-git clone https://github.com/yibie/org-supertag.git ~/org-supertag
-```
+## 🚀 30 秒上手
 
 ```emacs-lisp
-(straight-use-package 'ht)
-(straight-use-package 'gptel)
-
+;; 安装
 (straight-use-package '(org-supertag :host github :repo "yibie/org-supertag"))
-(setq org-supertag-sync-directories '("Your/Path/To/Org-Files/"))
-(eval-after-load 'gptel
-  '(require 'org-supertag))
+
+;; 配置目录
+(setq org-supertag-sync-directories '("~/org/"))
+
+;; 初始化（仅一次）
+M-x supertag-sync-full-initialize
 ```
 
-#### 第二步：创建你的第一个智能笔记
+## 🎯 核心概念
 
-1. 打开任意 .org 文件
-2. 创建标题：* 我的第一个项目
-3. 输入 # 并选择或创建标签
-4. 🎉 恭喜！你已经创建了一个智能节点
+传统标签：`#tag`  
+SuperTag：`#tag` + 结构化数据
 
-#### 第三步：探索强大功能
+```org
+* 项目计划 #project
+  - status: planning
+  - priority: high
+  - due: 2024-12-31
+```
 
-- `M-x supertag-view-node` - 查看节点详情（包含AI标签建议）
+## 📋 常用命令
+
+- `M-x supertag-add-tag` - 添加标签
+- `M-x supertag-view-node` - 查看节点详情  
 - `M-x supertag-search` - 智能搜索
+- `M-x supertag-capture` - 快速捕获
 - `M-x supertag-view-kanban` - 看板视图
-- `M-x supertag-chat` - AI对话
 
-### 🎯 使用场景
+## 🔍 查询示例
 
-#### 📚 学术研究
-```org
-#paper + 字段[期刊, 影响因子, 阅读状态, 笔记]
-#experiment + 字段[假设, 方法, 结果, 结论]
-#idea + 字段[灵感来源, 可行性, 优先级]
+```lisp
+;; 高优先级项目
+(supertag-search '(and (tag "project") 
+                       (field "priority" "high")))
+
+;; 未读论文
+(supertag-search '(and (tag "paper") 
+                       (field "status" "unread")))
 ```
 
-#### 💼 项目管理  
-```org
-#project + 字段[状态, 优先级, 负责人, 截止日期]
-#task + 字段[类型, 估时, 依赖, 完成度]
-#meeting + 字段[参与者, 议题, 决议, 后续行动]
-```
+## 🔄 4.x 迁移
 
-### 🚀 高级功能
+1. `M-x load-file RET supertag-migration.el RET`
+2. `M-x supertag-migrate-database-to-new-arch RET`  
+3. 重启 Emacs
 
-#### 🤖 智能自动化系统 (Automation 2.0)
-
-5.0 版本带来了全新的自动化系统，采用纯 Emacs Lisp 实现，性能更优，功能更强大：
-
-- ✅ **统一的标签系统**：每个标签都是功能完备的"数据库"，拥有自定义字段和自动化能力
-- ✅ **真正的事件驱动**：基于精确的数据变化实时响应，而非轮询扫描
-- ✅ **自动规则索引**：在后台自动为规则建立高性能索引，无需用户关心性能优化细节
-- ✅ **多重动作执行**：一条规则可以触发一系列按顺序执行的动作
-- ✅ **计划任务**：支持基于时间和周期的自动化，由集成的调度器驱动
-- ✅ **关系与计算**：支持双向关系、属性同步、Rollup 计算等高级功能
-- ✅ **公式字段**：在表格视图中实时计算和显示数据，无需持久化存储
-
-| 特性 | 旧版本 (Behavior) | 新版本 (Automation 2.0) |
-|------|-------------|-------------|
-| **模块结构** | 分散的多个模块，存在循环依赖 | 统一的单一模块，消除依赖问题 |
-| **规则管理** | 手动附加到标签，需要用户管理 | 自动索引，系统智能管理 |
-| **性能** | O(n) 遍历所有规则 | O(1) 索引查找，高性能 |
-| **API一致性** | 多套不同的API接口 | 统一的API接口，学习成本低 |
-| **维护性** | 复杂的模块间关系 | 简单的内聚设计，易于维护 |
-
-详情请查看 [Automation System Guide](doc/AUTOMATION-SYSTEM-GUIDE_cn.md)
-
-#### 📸 捕获系统 (Capture System)
-
-5.0 版本引入了全新的捕获系统，采用更自然的模板语法：
-
-- ✅ **直观的模板语法** - 类似 org-capture，直接编写模板字符串
-- ✅ **自动解析** - 自动识别标题、标签、字段和内容
-- ✅ **智能填充** - 支持交互式提示和占位符
-- ✅ **灵活配置** - 可指定文件或让用户选择
-
-##### 配置捕获模板
-
-通过配置 `supertag-capture-templates` 变量来定义模板：
+## ⚙️ 配置
 
 ```emacs-lisp
-(setq supertag-capture-templates
-      '(
-        ;; 快速任务
-        ("t" "快速任务"
-         :file "~/Documents/notes/plan.org"
-         :node-spec
-         (:template
-          "* %^{任务描述:} #task
-   - status: todo
-   - priority: medium
-   - create-at: %datetime
-
-  %?"))
-
-        ;; 问题记录
-        ("q" "问题记录"
-         :node-spec
-         (:template
-          "* #question %^{问题:}
-
-  %^{详细内容:}
-
-  %?"))
-
-        ;; 会议记录
-        ("m" "会议记录"
-         :file "~/org/meetings.org"
-         :node-spec
-         (:template
-          "* %^{会议主题:} #meeting
-   - type: %^{会议类型:}
-   - status: completed
-   - location: %^{地点:}
-
-  时间: %date
-  参会人员:
-
-  议程:
-
-  讨论要点:
-
-  行动项:
-
-  %?"))))
+(setq org-supertag-sync-directories '("~/notes/"))
 ```
-
-##### 模板语法说明
-
-**基本结构：**
-- 第一行：标题和内联标签 `* 标题 #tag1 #tag2`
-- 字段行：`- 字段名: 值`
-- 空行后：正文内容
-
-**交互式提示：**
-- `%^{提示文本}` - 提示用户输入
-
-**占位符：**
-- `%date` - 当前日期 (YYYY-MM-DD)
-- `%datetime` - 日期时间 (YYYY-MM-DD HH:MM)
-- `%time` - 当前时间
-- `%?` - 设置光标位置
-
-**配置选项：**
-- `:file` - 指定目标文件（可选，不指定则提示用户选择）
-- `:node-spec` - 节点规格，包含 `:template` 字符串
-
-##### 使用方法
-
-1. **模板捕获**：`M-x supertag-capture-with-template`，选择模板
-2. **直接捕获**：`M-x supertag-capture`，使用默认模板
-
-详情请查看 [Capture Guide](doc/CAPTURE-GUIDE_cn.md)
-
-### ⌨️ 键盘快捷键
-
-Org-SuperTag 不再默认安装全局快捷键。若想恢复经典的 `C-c s` 前缀，可以在加载 `org-supertag` 之后加入下面的配置示例：
-
-```emacs-lisp
-(with-eval-after-load 'org-supertag
-  (define-prefix-command 'supertag-prefix-map)
-  (define-key org-mode-map (kbd "C-c s") 'supertag-prefix-map)
-
-  ;; 捕获
-  (define-key supertag-prefix-map (kbd "C") #'supertag-capture)
-  (define-key supertag-prefix-map (kbd "t") #'supertag-capture-with-template)
-
-  ;; 标签管理
-  (define-key supertag-prefix-map (kbd "a") #'supertag-add-tag)
-  (define-key supertag-prefix-map (kbd "r") #'supertag-remove-tag-from-node)
-  (define-key supertag-prefix-map (kbd "n") #'supertag-rename-tag)
-  (define-key supertag-prefix-map (kbd "d") #'supertag-delete-tag-everywhere)
-  (define-key supertag-prefix-map (kbd "c") #'supertag-change-tag-at-point)
-  (define-key supertag-prefix-map (kbd "x") #'supertag-set-child)
-  (define-key supertag-prefix-map (kbd "X") #'supertag-clear-parent)
-
-  ;; 节点与引用
-  (define-key supertag-prefix-map (kbd "m") #'supertag-move-node-and-link)
-  (define-key supertag-prefix-map (kbd "l") #'supertag-add-reference)
-  (define-key supertag-prefix-map (kbd "L") #'supertag-add-reference-and-create)
-  (define-key supertag-prefix-map (kbd "R") #'supertag-remove-reference)
-  (define-key supertag-prefix-map (kbd "h") #'supertag-back-to-heading)
-  (define-key supertag-prefix-map (kbd "N") #'supertag-create-node)
-  (define-key supertag-prefix-map (kbd "D") #'supertag-delete-node)
-  (define-key supertag-prefix-map (kbd "f") #'supertag-find-node)
-  (define-key supertag-prefix-map (kbd "o") #'supertag-find-node-other-window)
-  (define-key supertag-prefix-map (kbd "M") #'supertag-move-node)
-  (define-key supertag-prefix-map (kbd "u") #'supertag-update-node-at-point)
-
-  ;; 查询与视图
-  (define-key supertag-prefix-map (kbd "i") #'supertag-insert-query-block)
-  (define-key supertag-prefix-map (kbd "s") #'supertag-search)
-  (define-key supertag-prefix-map (kbd "e") #'supertag-search-export-results-to-file)
-  (define-key supertag-prefix-map (kbd "E") #'supertag-search-export-results-to-new-file)
-  (define-key supertag-prefix-map (kbd "I") #'supertag-search-insert-at-point)
-  (define-key supertag-prefix-map (kbd "g") #'supertag-chat)
-  (define-key supertag-prefix-map (kbd "v") #'supertag-view-node)
-  (define-key supertag-prefix-map (kbd "T") #'supertag-view-table)
-  (define-key supertag-prefix-map (kbd "k") #'supertag-view-kanban)
-
-  ;; 嵌入与维护
-  (define-key supertag-prefix-map (kbd "b") #'supertag-insert-embed)
-  (define-key supertag-prefix-map (kbd "B") #'supertag-convert-link-to-embed)
-  (define-key supertag-prefix-map (kbd "C-r") #'supertag-services-embed-refresh-all)
-  (define-key supertag-prefix-map (kbd "C-c") #'supertag-sync-cleanup-database))
-```
-
-| 按键 | 命令 | 描述 |
-|------|------|------|
-| `C-c s C` | supertag-capture | 直接捕获 |
-| `C-c s t` | supertag-capture-with-template | 使用模板捕获 |
-| `C-c s a` | supertag-add-tag | 为当前节点添加标签 |
-| `C-c s r` | supertag-remove-tag-from-node | 从当前节点删除标签 |
-| `C-c s n` | supertag-rename-tag | 重命名标签 |
-| `C-c s d` | supertag-delete-tag-everywhere | 在所有地方删除标签 |
-| `C-c s c` | supertag-change-tag-at-point | 更改光标处的标签 |
-| `C-c s x` | supertag-set-child | 设置子标签 |
-| `C-c s X` | supertag-clear-parent | 清除标签父级 |
-| `C-c s m` | supertag-move-node-and-link | 移动节点并留下引用 |
-| `C-c s l` | supertag-add-reference | 为节点添加引用 |
-| `C-c s L` | supertag-add-reference-and-create | 添加引用并在不存在时创建节点 |
-| `C-c s R` | supertag-remove-reference | 从节点删除引用 |
-| `C-c s h` | supertag-back-to-heading | 返回标题 |
-| `C-c s N` | supertag-create-node | 创建新节点 |
-| `C-c s D` | supertag-delete-node | 删除节点 |
-| `C-c s f` | supertag-find-node | 查找节点 |
-| `C-c s o` | supertag-find-node-other-window | 在其他窗口查找节点 |
-| `C-c s M` | supertag-move-node | 移动节点 |
-| `C-c s u` | supertag-update-node-at-point | 更新光标处节点 |
-| `C-c s i` | supertag-insert-query-block | 插入查询块 |
-| `C-c s s` | supertag-search | 打开查询界面 |
-| `C-c s e` | supertag-search-export-results-to-file | 导出查询结果到文件 |
-| `C-c s E` | supertag-search-export-results-to-new-file | 导出查询结果到新文件 |
-| `C-c s I` | supertag-search-insert-at-point | 在光标处插入查询结果 |
-| `C-c s g` | supertag-chat | 打开聊天视图 |
-| `C-c s v` | supertag-view-node | 查看节点详情 |
-| `C-c s T` | supertag-view-table | 打开表格视图 |
-| `C-c s k` | supertag-view-kanban | 打开看板视图 |
-| `C-c s b` | supertag-insert-embed | 插入嵌入块 |
-| `C-c s B` | supertag-convert-link-to-embed | 将链接转换为嵌入 |
-| `C-c s C-r` | supertag-services-embed-refresh-all | 刷新全部嵌入 |
-| `C-c s C-c` | supertag-sync-cleanup-database | 清理数据库 |
-
-以上快捷键仅作参考，可根据自己的工作流进行增删。
-
-### 🔧 配置指南
-
-#### 基础配置
-```emacs-lisp
-;; 核心配置
-(setq org-supertag-sync-directories '("~/notes/" "~/projects/"))
-```
-
-#### AI 服务配置
-```emacs-lisp
-;; 控制是否启用 AI 服务
-;; 设置为 nil 可禁用 AI 服务，默认为 t
-(setq org-supertag-bridge-enable-ai nil)
-```
-
-#### 高级配置
-```emacs-lisp
-;; 自定义字段类型
-(add-to-list 'org-supertag-field-types
-  '(rating . (:validator org-supertag-validate-rating
-              :formatter org-supertag-format-rating
-              :description "评分 (1-5)")))
-
-;; 自定义查询命令
-(defun my-urgent-projects ()
-  "查找所有紧急项目"
-  (interactive)
-  (supertag-search '(and (tag "project") (tag "urgent"))))
-```
-
-### 🆚 对比其他工具
-
-| 功能 | Org-SuperTag | Org-roam | Obsidian | Notion |
-|------|--------------|----------|----------|--------|
-| 结构化数据 | ✅ 原生支持 | ❌ | ⚠️ 插件 | ✅ |
-| 复杂查询 | ✅ S表达式 | ⚠️ 基础 | ⚠️ 基础 | ✅ |
-| 自动化行为 | ✅ 强大 | ❌ | ⚠️ 有限 | ⚠️ 有限 |
-| AI集成 | ✅ 深度集成 | ❌ | ⚠️ 插件 | ✅ |
-| 离线使用 | ✅ | ✅ | ✅ | ❌ |
-| 学习曲线 | ⚠️ 中等 | ⚠️ 中等 | ✅ 简单 | ✅ 简单 |
-
-### 🤝 社区与支持
-
-- 📖 [详细文档](https://github.com/yibie/org-supertag/wiki)
-- 🐛 [问题反馈](https://github.com/yibie/org-supertag/issues)
-- 💬 [社区讨论](https://github.com/yibie/org-supertag/discussions)
-
-### Changelog
-详细见 [CHANGELOG](./CHANGELOG.org)
-
-#### 🆘 常见问题
-
-##### Q: 数据库损坏怎么办？
-A: 使用 =M-x supertag-sync-cleanup-database= 进行完整恢复。
-
-##### Q: 如何备份数据？
-A: Org-SuperTag 提供了自动每日备份功能：
-
-**自动备份**：
-- 每日备份会自动创建在 `~/.emacs.d/org-supertag/backups/` 目录
-- 保留最近3天的备份（可配置）
-- 旧备份会自动清理
-- 备份文件命名格式：`supertag-db-YYYY-MM-DD.el`
-
-**手动备份**：
-- 强制备份：`M-x supertag-backup-database-now`
-- 手动备份整个目录：`~/.emacs.d/org-supertag/`
-
-**配置选项**：
-```emacs-lisp
-;; 设置备份间隔（秒，默认86400=24小时）
-(setq supertag-db-backup-interval 86400)
-
-;; 设置备份保留天数（默认3天）
-(setq supertag-db-backup-keep-days 3)
-
-;; 禁用自动备份
-(setq supertag-db-backup-interval nil)
-```
-
-##### Q: 如何获取AI标签建议？
-A: 在节点视图（=M-x supertag-view-node=）中，点击"💡 Get AI Tag Suggestions"或按 =s= 键。这是手动触发的，不会干扰你的工作流程。
-
-##### Q: AI功能需要什么配置？
-A: AI功能使用默认的Ollama配置，无需额外设置。所有AI功能都集成在现有的视图系统中，使用简单直观。
-
-### 🎉 立即开始
-
-> 不要让复杂的功能吓到你！Org-SuperTag 的设计理念是"简单开始，逐步深入"。
->
-> 从添加第一个 =#标签= 开始，逐步探索结构化数据、智能查询、AI助手等高级功能。
->
-> 每一个功能都是为了让你的知识管理更加高效和智能。
-
 
 ---
 
-*Made with ❤️ by [Yibie](https://github.com/yibie) | 受到 [Tana](https://tana.inc)、[ekg](https://github.com/ahyatt/ekg)、[org-node](https://github.com/meedstrom/org-node) 的启发*
+*为 Emacs 用户设计的 Notion 级知识管理*

--- a/doc/CAPTURE-GUIDE_cn.md
+++ b/doc/CAPTURE-GUIDE_cn.md
@@ -31,7 +31,48 @@ M-x supertag-capture-with-template RET t RET
 
 ## 📖 使用指南
 
-### 两种捕获方式
+### 总览：三种典型工作流
+
+- **基于 org-capture 的捕获**（`org-capture` + Supertag）：复用现有 `org-capture-templates`，由 Supertag 接管 ID、数据库、字段、移动和标签。
+- **模板捕获**（`supertag-capture-with-template`）：使用 DSL + 动态生成器 + 字段规范的高级捕获。
+- **独立捕获**（`supertag-capture`）：一次性、轻量级创建节点。
+
+底层由一个统一的“最终定稿 API”负责：把当前 Org 标题转换为 Supertag 节点，并按 Tag/Field/Value 模型写入字段。
+
+### 基于 org-capture 的捕获（推荐给已有 org-capture 用户）
+
+如果你已经在日常使用 org-capture，这条路线是最自然的：
+
+1. 启用 Supertag 与 org-capture 的集成：
+   ```elisp
+   (setq supertag-org-capture-auto-enable t)
+   ;; 或：
+   ;; (supertag-enable-org-capture-integration)
+   ```
+2. 在你的 org-capture 模板上添加 `:supertag` 以及可选扩展：
+   ```elisp
+   (add-to-list 'org-capture-templates
+                '("t" "带 Supertag 的任务" entry
+                  (file+headline "~/org/tasks.org" "Inbox")
+                  "* TODO %^{任务}\n  %?\n"
+                  :supertag t
+                  :supertag-tags-prompt t
+                  :supertag-template ((:tag "task" :field "status" :value "todo"))
+                  :supertag-move 'link))  ;; 捕获后移动并在原位置留链接
+   ```
+
+整体流程：
+
+- org-capture 按模板插入标题和正文；
+- Supertag 对该节点做“最终定稿”：确保 `ID`、同步数据库、写入字段（`:supertag-template`）；
+- 如果设置了 `:supertag-tags-prompt t`：
+  - 会弹出一个基于 Supertag 标签库的补全界面，可从已有标签中选择，或输入新标签（自动创建为正式 Supertag 标签）；
+- 如果设置了 `:supertag-move`，则在定稿后触发 Supertag 的移动逻辑：
+  - `:supertag-move t` / `node` → 调用 `supertag-move-node`，交互式选择“文件 + 位置”；
+  - `:supertag-move link` / `:link` → 调用 `supertag-move-node-and-link`，移动并在原处留链接；
+  - `:supertag-move within-target` / `:within-target` → 只在 **当前 capture 目标文件内部**选择插入位置（跳过文件选择对话框）。
+
+### 两种内置捕获方式
 
 #### 1. 独立捕获 (`supertag-capture`)
 
@@ -412,11 +453,110 @@ M-x supertag-capture-with-template
 
 ### 用户命令
 
-| 命令                             | 描述                 | 使用方式                                       |
-| -------------------------------- | -------------------- | ---------------------------------------------- |
-| `supertag-capture`               | 独立的捕获命令       | `M-x supertag-capture`                         |
-| `supertag-capture-with-template` | 基于模板的捕获命令   | `M-x supertag-capture-with-template`           |
-| `supertag-capture-enrich-node`   | 交互式丰富节点字段值 | `M-x supertag-capture-enrich-node RET node-id` |
+| 命令                             | 描述                       | 使用方式                                       |
+| -------------------------------- | -------------------------- | ---------------------------------------------- |
+| `supertag-capture`               | 独立的捕获命令             | `M-x supertag-capture`                         |
+| `supertag-capture-with-template` | 基于模板的捕获命令         | `M-x supertag-capture-with-template`           |
+| `supertag-capture-enrich-node`   | 交互式丰富节点字段值       | `M-x supertag-capture-enrich-node RET node-id` |
+
+### 与 org-capture 的集成（可选）
+
+Org-Supertag 可以作为 `org-capture` 的一个“后处理层”：  
+继续使用你原本的 `org-capture-templates`，只在 capture 完成后，由 Supertag 负责：
+
+- 确保节点有稳定的 `ID`
+- 同步到 Supertag 数据库
+- 写入字段（Tag/Field/Value 模型）
+
+#### 启用集成
+
+```elisp
+;; 全局启用 org-capture 集成
+(setq supertag-org-capture-auto-enable t)
+;; 或交互式调用：
+;; M-x supertag-enable-org-capture-integration
+```
+
+这会在 `org-capture-after-finalize-hook` 上注册一个钩子，  
+只对显式标记了 `:supertag t` 的模板生效。
+
+#### 在 org-capture 模板中开启 Supertag 支持
+
+在模板 plist 中加入 `:supertag t` 即可让这个模板的结果变成 Supertag 节点：  
+可选的 `:supertag-template` 用于在捕获后自动写入字段：
+
+```elisp
+(add-to-list 'org-capture-templates
+             '("t" "带 Supertag 的任务" entry
+               (file+headline "~/org/tasks.org" "Inbox")
+               "* TODO %^{任务}  #task\n  %?\n"
+               :supertag t
+               :supertag-template ((:tag "task" :field "status" :value "todo"))))
+```
+
+完成后，Supertag 会：
+
+- 确保节点有稳定 `ID`
+- 同步到 Supertag 数据库
+- 根据 `:supertag-template` 写入字段
+
+#### 把 org-capture 和 `supertag-move-node` 结合起来
+
+你可以复刻“org-capture + org-refile”的习惯工作流：  
+先用 org-capture 创建节点，然后用 Supertag 的移动命令把节点放到真正位置。
+
+在模板里添加 `:supertag-move`，即可在 capture 完成后自动调用移动命令：
+
+```elisp
+(add-to-list 'org-capture-templates
+             '("m" "任务（Supertag + 移动）" entry
+               (file "~/org/inbox.org")
+               "* TODO %^{任务}  #task\n  %?\n"
+               :supertag t
+               :supertag-move t))      ;; 使用 supertag-move-node
+
+(add-to-list 'org-capture-templates
+             '("l" "任务（Supertag + 移动并留链接）" entry
+               (file "~/org/inbox.org")
+               "* %^{标题}  #task\n  %?\n"
+               :supertag t
+               :supertag-move 'link))  ;; 使用 supertag-move-node-and-link
+```
+
+- `:supertag-move t` 或 `:supertag-move 'node`  
+  → capture 结束后调用 `supertag-move-node`，弹出“目标文件 + 插入位置”的交互。  
+- `:supertag-move 'link` 或 `:supertag-move :link`  
+  → capture 结束后调用 `supertag-move-node-and-link`，把节点移走并在原处留下指向该节点的链接。
+
+这等价于经典的“org-capture + org-refile”两步流，但第二步由 Supertag 的移动 API 完成，并自动更新数据库中的位置信息。
+
+#### 在 org-capture 过程中交互式选择 Supertag 标签
+
+如果你希望在 capture 完成后立刻用 Supertag 的标签补全界面来选择标签，可以在模板中添加 `:supertag-tags-prompt t`：
+
+```elisp
+(add-to-list 'org-capture-templates
+             '("s" "带标签选择的 Supertag 任务" entry
+               (file "~/org/inbox.org")
+               "* TODO %^{任务}\n  %?\n"
+               :supertag t
+               :supertag-tags-prompt t))
+```
+
+正确使用步骤：
+
+1. 先启用 org-capture 集成，例如：
+   ```elisp
+   (setq supertag-org-capture-auto-enable t)
+   ;; 或： (supertag-enable-org-capture-integration)
+   ```
+2. 使用上面的模板执行 org-capture，org-capture 按模板插入标题和内容
+3. Supertag 对该标题做“最终定稿”：确保 ID、同步数据库
+4. 随后弹出一个提示：`Supertag tags (comma separated):`
+5. 你可以：
+   - 从现有的 Supertag 标签中选择（支持补全、多选），或
+   - 直接输入新的标签名称；不存在的标签会自动创建为正式 Supertag 标签
+6. Supertag 同时更新数据库中的标签集，并在标题中追加对应的 `#tag`
 
 ### 内容生成器函数
 
@@ -432,13 +572,14 @@ M-x supertag-capture-with-template
 
 ## 🆚 与 Org-Capture 的对比
 
-| 特性     | Org-Capture    | Supertag-Capture  |
-| -------- | -------------- | ----------------- |
-| 模板配置 | 静态字符串模板 | 动态内容生成器    |
-| 标签支持 | 手动输入       | 交互选择+自动完成 |
-| 字段管理 | 属性抽屉       | 数据库字段系统    |
-| 内容来源 | 固定格式       | 多种生成器        |
-| 扩展性   | 有限           | 高度可扩展        |
+| 特性         | Org-Capture            | Supertag 捕获 / 集成层         |
+| ------------ | ---------------------- | ------------------------------- |
+| 模板配置     | 静态字符串模板         | 动态内容生成器 + node-spec DSL |
+| 标签支持     | 手动输入               | 交互选择 + 自动完成             |
+| 字段管理     | 属性抽屉               | 数据库字段系统                 |
+| 内容来源     | 固定格式               | 多种生成器                     |
+| 扩展方式     | 有限                   | 高度可扩展                     |
+| 集成方式     | N/A                    | 通过 hook 做后处理             |
 
 ## 🐛 故障排除
 
@@ -459,6 +600,27 @@ M-x supertag-capture-with-template
 2. 检查 `*Messages*` 缓冲区的错误信息
 3. 验证模板配置的语法正确性
 4. 确认所有依赖的文件和标签存在
+
+## 🧩 开发者说明：核心捕获 API
+
+如果你希望编写自己的前端（例如从其它命令里创建节点），可以直接调用底层的“最终定稿” API，将当前 Org 标题转为 Supertag 节点：
+
+```elisp
+;; 在你希望变成 Supertag 节点的标题上调用：
+(supertag-capture-finalize-node-at-point
+ '((:tag "task" :field "status" :value "todo")
+   (:tag "task" :field "priority" :value "high")))
+```
+
+这会：
+
+- 确保该标题有稳定的 `ID`（必要时自动创建）
+- 使用 `org-id` 注册 ID 与文件路径的映射
+- 同步节点到 Supertag 数据库
+- 按给定的 Tag/Field/Value 规格调用 `supertag-field-set-many` 写入字段
+
+org-capture 集成和 `supertag-capture-with-template` 内部都使用了这个函数。  
+在构建新的捕获流程时，推荐复用该 API，而不是重复实现同步逻辑。
 
 ---
 


### PR DESCRIPTION
## Improvements

### Org-Capture Integration as a First-Class Capture Path

- Added a unified finalization API `supertag-capture-finalize-node-at-point` that turns any Org heading into a Supertag node, ensuring a stable `ID`, syncing to the database, and applying tag fields in one place.
- `supertag-capture-with-template` and the new org-capture integration now both rely on this core API, avoiding duplicated sync logic.
- Introduced `supertag-org-capture-after-finalize` hook integration:
  - Templates can opt in with `:supertag t` in `org-capture-templates`.
  - Optional `:supertag-template` lets org-capture templates pre-fill tag fields using the Tag/Field/Value model.

### Supertag-Aware Tag Prompt in org-capture

- New `:supertag-tags-prompt` option for org-capture templates:
  - After capture finalization, prompts `Supertag tags (comma separated):` with completion from existing Supertag tags.
  - Supports creating new tags on the fly: names are sanitized and missing tags are automatically created as Tag entities.
  - Selected tags are written both to the Supertag database and to the Org headline as inline `#tag`, then re-synced in one pass.

### Movement Workflow: org-capture + Supertag Move

- Extended `:supertag-move` options to chain capture → finalize → move:
  - `t` / `node` → run `supertag-move-node` for full file+position selection.
  - `link` / `:link` → run `supertag-move-node-and-link`, moving the node and leaving a backlink at the original location.
  - `within-target` / `:within-target` → only select a position within the capture target file, skipping the file prompt for a smoother "in-file re-positioning" flow.
- This replaces the need to use `org-refile` for Supertag nodes, while staying compatible with org-capture's templating model.

### Capture DSL and org-capture Symmetry

- Clarified the roles of:
  - `supertag-capture-with-template`: advanced DSL for Supertag-native capture flows.
  - org-capture integration: lightweight path that reuses existing `org-capture-templates` and adds Supertag-specific post-processing via `:supertag`, `:supertag-template`, `:supertag-tags-prompt`, and `:supertag-move`.
- Updated `doc/CAPTURE-GUIDE.md` and `doc/CAPTURE-GUIDE_cn.md`:
  - Org-capture based capture is now documented as a first-class, recommended workflow for existing Org users.
  - Added concrete examples for `:supertag-template`, `:supertag-tags-prompt`, and `:supertag-move within-target`, and a developer section for the core finalization API.

#### Implementation Notes

- Files touched: `supertag-services-capture.el`, `supertag-ui-commands.el`, `doc/CAPTURE-GUIDE.md`, `doc/CAPTURE-GUIDE_cn.md`.
- `supertag-org-capture-after-finalize` now normalizes `:supertag-move` values from quoted and string forms and safely checks for the presence of move commands (`supertag-move-node`, `supertag-move-node-and-link`) before calling them.