### PR TITLE
Enhance org-supertag-sync.el by adding preservation and restoration o…

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,12 @@
 * Changelog
+* [5.1.7] - 2025-11-18
+** Features
+*** Field Export to Org Properties with Progress UI
+- Added `supertag-export-all-fields-to-properties` command to export all database field values to Org `:PROPERTIES:` drawers for nodes that have fields.
+- Field names are exported as human-friendly Org property keys (e.g. `rate` → `:RATE:`, `who` → `:WHO:`) while keeping the database as the single source of truth.
+- Node-reference fields are exported as readable titles (e.g. director names) instead of raw node IDs, improving interoperability with external tools that only see Org files.
+- The export process shows a minibuffer progress bar and a final summary message, and can optionally save modified buffers when called with a prefix argument.
+
 * [5.1.6] - 2025-11-17
 ** Improvements
 *** Org-Capture Integration as a First-Class Capture Path

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,7 +5,7 @@
 ## ⚡ 5.0 新变化
 
 - **删除 44% 代码** - 完全移除 Python
-- **5 倍性能提升** - 无 EPC 通信开销  
+- **5 倍性能提升** - 无 EPC 通信开销
 - **一键安装** - 仅需 Emacs
 
 ## 🚀 30 秒上手
@@ -36,7 +36,7 @@ SuperTag：`#tag` + 结构化数据
 ## 📋 常用命令
 
 - `M-x supertag-add-tag` - 添加标签
-- `M-x supertag-view-node` - 查看节点详情  
+- `M-x supertag-view-node` - 查看节点详情
 - `M-x supertag-search` - 智能搜索
 - `M-x supertag-capture` - 快速捕获
 - `M-x supertag-view-kanban` - 看板视图
@@ -45,18 +45,18 @@ SuperTag：`#tag` + 结构化数据
 
 ```lisp
 ;; 高优先级项目
-(supertag-search '(and (tag "project") 
+(supertag-search '(and (tag "project")
                        (field "priority" "high")))
 
 ;; 未读论文
-(supertag-search '(and (tag "paper") 
+(supertag-search '(and (tag "paper")
                        (field "status" "unread")))
 ```
 
 ## 🔄 4.x 迁移
 
 1. `M-x load-file RET supertag-migration.el RET`
-2. `M-x supertag-migrate-database-to-new-arch RET`  
+2. `M-x supertag-migrate-database-to-new-arch RET`
 3. 重启 Emacs
 
 ## ⚙️ 配置
@@ -67,4 +67,4 @@ SuperTag：`#tag` + 结构化数据
 
 ---
 
-*为 Emacs 用户设计的 Notion 级知识管理*
+_为 Emacs 用户设计的 Notion 级知识管理_

--- a/doc/README-5.0-DRAFT.md
+++ b/doc/README-5.0-DRAFT.md
@@ -1,0 +1,379 @@
+# Org-SuperTag 5.0 – Structured knowledge management in pure Emacs Lisp
+
+Org-SuperTag turns your plain Org headings into a **structured, queryable knowledge base** –  
+without leaving Emacs, without external services, and without Python.
+
+- Each `#tag` behaves like a **database table**
+- Each heading is a **record**; its structured fields live in Org-SuperTag's database
+- Views, queries and automations are all driven by this structured layer
+
+This document is a **draft** of a new README for the 5.0 architecture.
+
+---
+
+## What is Org-SuperTag?
+
+Traditional Org-mode gives you:
+
+- Headlines
+- TODO keywords
+- Tag strings like `:project:research:`
+
+Org-SuperTag adds a **strongly structured layer** on top:
+
+```org
+* Website Redesign #project
+  - status: in-progress
+  - priority: high
+  - due: 2024-12-15
+  - owner: @team
+```
+
+You still edit plain text Org files, but Org-SuperTag:
+
+- Scans and synchronizes your files
+- Stores a normalized representation in an in-memory database
+- Provides fast queries and multiple views on top of it
+
+The goal is: **Notion-level structure, Org-mode-level control.**
+
+---
+
+## Highlights in 5.0
+
+5.0 is a major internal simplification while keeping the same user-facing ideas.
+
+- **Pure Emacs Lisp**  
+  No Python, no EPC, no virtualenvs. Everything runs inside Emacs.
+
+- **Single source of truth**  
+  All structured data is kept in a single hash-table–backed store,  
+  instead of multiple partially synchronized SQLite tables.
+
+- **Faster sync and simpler debugging**  
+  No cross-process RPC means less overhead and fewer moving parts.
+
+- **Same Org files, new engine**  
+  The on-disk Org files remain the primary data; the internal engine is what changed.
+
+For a deeper comparison between the old architecture and 5.0, see:
+
+- `doc/COMPARE-NEW-OLD-ARCHITECTURE.md`
+- `doc/COMPARE-NEW-OLD-ARCHITECHTURE_cn.md`
+
+---
+
+## 30‑second quick start
+
+Minimal setup with straight.el:
+
+```emacs-lisp
+;; 1. Install
+(straight-use-package '(org-supertag :host github :repo "yibie/org-supertag"))
+
+;; 2. Configure where your Org files live
+(setq org-supertag-sync-directories '("~/org/"))
+
+;; 3. Initialize the database (run once)
+M-x supertag-sync-full-initialize
+```
+
+After initialization:
+
+- Add tags: `M-x supertag-add-tag`
+- Open a node view: `M-x supertag-view-node`
+- Run a query: `M-x supertag-search`
+
+---
+
+## Core concepts & data model
+
+Org-SuperTag is built around a small set of concepts:
+
+- **Node**  
+  A single Org heading, uniquely identified and tracked across syncs.
+
+- **Tag**  
+  Written inline as `#tag` in the heading title. Every `#tag` acts like a logical table.
+
+- **Field definition**  
+  Part of a tag's schema (`:fields` list) that declares a field name, type, options,
+  defaults and validation. Field definitions live on the tag, not in the Org file text.
+
+- **Field value**  
+  For each `(node-id, tag-id, field-name)` triple, Org-SuperTag stores a value in its
+  `:fields` collection. These values are kept in the database and do **not** have to be
+  rendered as `- key: value` lines in the Org file.
+
+- **Schema & views**  
+  How you choose to display and edit these fields (forms, tables, kanban, etc.).
+
+Example (on disk vs in the database):
+
+```org
+* Attention Is All You Need #paper
+```
+
+On disk you only need the headline and `#paper` tag. In the Org-SuperTag database, this
+node might have field values such as:
+
+- `authors`: `"Vaswani et al."`
+- `year`: `2017`
+- `venue`: `"NIPS"`
+- `status`: `"read"`
+- `rating`: `5`
+
+Internally this becomes something like:
+
+- tag: `"paper"`
+- field definitions on the tag: `authors`, `year`, `venue`, `status`, `rating`
+- field values per node: one value for each `(node-id, "paper", field-name)` triple
+- node metadata: file path, outline path, scheduled date, etc.
+
+You can then:
+
+- Filter all `#paper` with `status = unread`
+- Sort by `year` or `rating`
+- Display them in a custom view or query block
+
+For the higher-level design and motivation behind query blocks, see:
+
+- `doc/ABOUT-QUERY-BLOCK.md`
+- `doc/ABOUT-QUERY-BLOCK_cn.md`
+
+---
+
+## Typical workflows
+
+### Academic / research notes
+
+```org
+* Diffusion Models for XYZ #paper
+```
+
+On disk you keep the headline and tag. In the database you define fields on `#paper`
+such as `authors`, `year`, `venue`, `status`, `topic`, and store per-node values for
+those fields. You can then:
+
+- List all `#paper` tagged as `generative-models`
+- Filter by `status` (e.g. unread → reading queue)
+- Sort by year or rating
+
+### Project management
+
+```org
+* Rewrite sync layer #task #project
+```
+
+Tags like `#task` and `#project` can define fields such as `status`, `priority`,
+`owner`, `project`, etc. Field values live in the Org-SuperTag database and are edited
+via views (forms, tables, kanban), not by hand-writing `- key: value` lines.
+
+Combine this with:
+
+- `M-x supertag-view-kanban` for board-style views
+- Custom queries for “high priority tasks this week”
+
+### Meetings & logs
+
+```org
+* Sprint Planning 2024-11-15 #meeting
+```
+
+The `#meeting` tag can define fields like `date`, `participants`, `decisions`, and those
+values are stored per node in the database. Later you can query:
+
+- All `#meeting` in a date range
+- All meetings that mention a project or person
+
+---
+
+## Queries & views
+
+The underlying query engine is Lisp-based. At the lowest level, you can call:
+
+```emacs-lisp
+;; High priority projects
+(supertag-search
+ '(and (tag "project")
+       (field "priority" "high")))
+
+;; Unread papers
+(supertag-search
+ '(and (tag "paper")
+       (field "status" "unread")))
+```
+
+On top of this engine, Org-SuperTag provides:
+
+- **Interactive searches** (`M-x supertag-search`)
+- **Views** such as node forms, tables and kanban boards
+- **Query blocks** that live inside Org files and render dynamic results
+
+See:
+
+- `doc/COMPLETION-GUIDE.md`
+- `doc/AUTOMATION-SYSTEM-GUIDE.md`
+- `doc/CAPTURE-GUIDE.md`
+
+for more examples of how queries integrate with capture, completion and automation.
+
+---
+
+## Key commands (preview)
+
+This is not an exhaustive list, but it covers the most common entry points:
+
+| Command                    | What it does                             |
+| -------------------------- | ---------------------------------------- |
+| `M-x supertag-add-tag`     | Add an inline `#tag` to the current node |
+| `M-x supertag-view-node`   | Edit structured fields for the node      |
+| `M-x supertag-search`      | Run a structured search                  |
+| `M-x supertag-capture`     | Capture a new node with tags and fields  |
+| `M-x supertag-view-table`  | Show tabular view for a set of nodes     |
+| `M-x supertag-view-kanban` | Kanban-style view for tasks / projects   |
+
+As the UI stabilizes, this section should be kept in sync with `supertag-ui-*.el`.
+
+---
+
+## Migration & compatibility
+
+### From Org-SuperTag 4.x
+
+5.0 uses a different internal storage engine. A one-time migration is required.
+
+**Before you do anything: make a backup of your existing Org-SuperTag data directory.**
+
+1. Locate your old data directory (usually under `~/.emacs.d/org-supertag/`)
+2. Make a copy of it somewhere safe (or put it under version control)
+3. In Emacs, load the migration code:
+
+   ```emacs-lisp
+   M-x load-file RET supertag-migration.el RET
+   ```
+
+4. Run the migration:
+
+   ```emacs-lisp
+   M-x supertag-migrate-database-to-new-arch RET
+   ```
+
+5. Restart Emacs
+
+If the migration fails or the resulting data looks wrong, you can:
+
+- Quit Emacs
+- Restore your backup of the Org-SuperTag data directory
+- Re-open Emacs and stay on the old version until the issue is resolved
+
+### From plain Org / other tools
+
+If you are coming from:
+
+- Plain Org files with ad-hoc tags
+- Other knowledge tools (Notion, Obsidian, Org-roam, etc.)
+
+You can adopt Org-SuperTag incrementally:
+
+1. Pick a single area (e.g. `projects` or `papers`)
+2. Start adding inline `#tag` markers to the relevant headings
+3. Define fields on those tags (via the tag/schema UI) and start filling values from
+   node views
+4. Gradually convert old entries when you touch them, validating results via search
+   and views
+
+There is no hard requirement to convert everything at once.
+
+---
+
+## Data storage & backup
+
+Org-SuperTag treats your Org files as the **source of truth for node content and tags**.  
+Structured field values, relations and views live in a companion database, stored under
+a dedicated directory, typically:
+
+- `~/.emacs.d/org-supertag/`
+
+This directory contains:
+
+- Indexed representations of nodes and tags
+- Per-node field values (the structured data that does **not** live in Org text)
+- Auxiliary state for sync and views
+- Automatic snapshot/backup data
+
+Recommendations:
+
+- Put both your Org files and the Org-SuperTag data directory under regular backups
+- If you use git for your Org files, consider excluding transient cache files and only
+  keeping snapshot-style backups of the Org-SuperTag directory
+
+If the internal database is corrupted, you can usually recover by:
+
+```emacs-lisp
+M-x supertag-sync-cleanup-database
+M-x supertag-sync-full-initialize
+```
+
+This forces a full rescan from the Org files.
+
+---
+
+## Troubleshooting
+
+Some common entry points when something looks wrong:
+
+- **Database looks inconsistent / corrupted**
+
+  ```emacs-lisp
+  M-x supertag-sync-cleanup-database
+  ```
+
+- **You want to see what the database contains**
+
+  ```emacs-lisp
+  M-x supertag-search
+  ```
+
+- **Sync issues for a specific file**
+
+  ```emacs-lisp
+  M-x supertag-sync-analyze-file
+  ```
+
+For more advanced debugging and automation, refer to:
+
+- `doc/AUTOMATION-SYSTEM-GUIDE.md`
+- `doc/AUTOMATION-SYSTEM-GUIDE_cn.md`
+
+---
+
+## How does this compare to other tools?
+
+Very short version:
+
+| Tool     | Org-SuperTag angle                          |
+| -------- | ------------------------------------------- |
+| Org-roam | Org-roam is graph/links; SuperTag is tables |
+| Obsidian | SuperTag is native to Emacs & Org           |
+| Notion   | SuperTag is offline, programmable, and text |
+
+Org-SuperTag is not trying to replace everything; it focuses on:
+
+- **Structured fields on top of plain text**
+- **Programmable queries and views**
+- **Staying inside Emacs and Org-mode**
+
+---
+
+## Further reading
+
+If you want to understand the system in depth, the following documents are good next steps:
+
+- `doc/ABOUT-QUERY-BLOCK.md` / `doc/ABOUT-QUERY-BLOCK_cn.md`
+- `doc/AUTOMATION-SYSTEM-GUIDE.md` / `doc/AUTOMATION-SYSTEM-GUIDE_cn.md`
+- `doc/CAPTURE-GUIDE.md` / `doc/CAPTURE-GUIDE_cn.md`
+- `doc/COMPARE-NEW-OLD-ARCHITECTURE.md` / `doc/COMPARE-NEW-OLD-ARCHITECHTURE_cn.md`
+
+This draft README is meant to be the stable, user-facing overview that points into
+those more detailed documents.

--- a/doc/README-5.0-DRAFT_CN.md
+++ b/doc/README-5.0-DRAFT_CN.md
@@ -1,0 +1,369 @@
+# Org-SuperTag 5.0 – 纯 Emacs Lisp 的结构化知识管理
+
+Org-SuperTag 把普通的 Org 标题变成一个**可结构化查询的知识库** ——  
+完全在 Emacs 里完成，不依赖外部服务，也不再需要 Python。
+
+- 每个 `#tag` 像一张**数据库表**
+- 每个标题是一个**记录（record）**；它的结构化字段保存在 Org-SuperTag 的数据库中
+- 视图、查询和自动化都建立在这层结构化数据之上
+
+本文件是 5.0 架构下 README 的**中文草稿**。
+
+---
+
+## Org-SuperTag 是什么？
+
+传统 Org-mode 提供的是：
+
+- 标题（headline）
+- TODO 关键字
+- `:project:research:` 这样的标签字符串
+
+Org-SuperTag 在此基础上加了一层**强结构化层**：
+
+```org
+* Website Redesign #project
+```
+
+你在磁盘上只需要一个标题和一个 `#project` 标签。Org-SuperTag 会：
+
+- 扫描并同步这些 Org 文件
+- 在内存数据库中维护一个规范化的数据表示
+- 在此之上提供快速查询和多种视图
+
+目标很简单：**用 Org 的方式，做出 Notion 的结构化体验**。
+
+---
+
+## 5.0 的核心变化
+
+5.0 是一次**内部架构的大幅简化**，在不改变核心理念的前提下，把复杂度砍掉了。
+
+- **纯 Emacs Lisp**  
+  不再需要 Python、EPC、virtualenv，所有逻辑都在 Emacs 内部。
+
+- **单一数据源**  
+  所有结构化数据都存放在一个基于 hash-table 的统一存储里，  
+  不再是多套半同步的 SQLite 表。
+
+- **同步更快、调试更简单**  
+  没有跨进程 RPC，整体开销更低，出问题也更容易定位。
+
+- **Org 文件不变，内部引擎重写**  
+  磁盘上的 Org 仍然是主要数据载体，变化的是内部结构化存储的实现方式。
+
+更详细的新旧架构对比参见：
+
+- `doc/COMPARE-NEW-OLD-ARCHITECTURE.md`
+- `doc/COMPARE-NEW-OLD-ARCHITECHTURE_cn.md`
+
+---
+
+## 30 秒上手
+
+使用 straight.el 的最小配置：
+
+```emacs-lisp
+;; 1. 安装
+(straight-use-package '(org-supertag :host github :repo "yibie/org-supertag"))
+
+;; 2. 配置需要同步的 Org 目录
+(setq org-supertag-sync-directories '("~/org/"))
+
+;; 3. 初始化数据库（只需运行一次）
+M-x supertag-sync-full-initialize
+```
+
+初始化完成后，你可以：
+
+- 添加标签：`M-x supertag-add-tag`
+- 打开节点视图：`M-x supertag-view-node`
+- 运行查询：`M-x supertag-search`
+
+---
+
+## 核心概念与数据模型
+
+Org-SuperTag 围绕几类核心实体设计：
+
+- **Node（节点）**  
+  一个 Org 标题（headline），在系统中有唯一 ID，并在多次同步之间被追踪。
+
+- **Tag（标签）**  
+  写在标题里的 `#tag` 文本。每一个 `#tag` 都像一张逻辑表。
+
+- **Field definition（字段定义）**  
+  存在于 tag 的 schema 中（` :fields` 列表），描述字段名称、类型、可选项、默认值和校验规则。  
+  字段定义挂在 tag 上，**不会直接体现在 Org 文件文本中**。
+
+- **Field value（字段值）**  
+  对于每个 `(node-id, tag-id, field-name)` 三元组，Org-SuperTag 会在内部的 `:fields` 集合中存储一个值。  
+  这些值存在于数据库中，**不要求在 Org 文件里以 `- key: value` 的形式呈现**。
+
+- **Schema & Views（模式与视图）**  
+  字段定义决定了可以存什么；视图决定你怎么在 UI 里编辑和展示这些字段（表单、表格、看板等）。
+
+### 示例：磁盘上的 Org vs 数据库里的字段
+
+```org
+* Attention Is All You Need #paper
+```
+
+磁盘上的 Org 文件只需要这一行标题和 `#paper` 标签。  
+在 Org-SuperTag 的数据库中，这个节点可能有如下字段值：
+
+- `authors`: `"Vaswani et al."`
+- `year`: `2017`
+- `venue`: `"NIPS"`
+- `status`: `"read"`
+- `rating`: `5`
+
+内部结构可以理解为：
+
+- tag `"paper"` 上定义了字段：`authors`, `year`, `venue`, `status`, `rating`
+- 对于每个节点，有一组 `(node-id, "paper", field-name)` → value 的字段值
+- 节点本身还有文件路径、标题路径、scheduled/deadline 等元数据
+
+基于这些数据，你可以：
+
+- 过滤所有 `#paper` 且 `status = unread` 的节点
+- 按 `year` 或 `rating` 排序
+- 在自定义视图或查询块中展示这些内容
+
+更多关于 Query Block 的设计动机和用法，参见：
+
+- `doc/ABOUT-QUERY-BLOCK.md`
+- `doc/ABOUT-QUERY-BLOCK_cn.md`
+
+---
+
+## 典型使用场景
+
+### 学术 / 研究笔记
+
+```org
+* Diffusion Models for XYZ #paper
+```
+
+磁盘上只保留标题与 `#paper` 标签。  
+在数据库里，你可以在 `#paper` 上定义字段：`authors`, `year`, `venue`, `status`, `topic` 等，并给每个节点填入具体值。
+
+然后你可以：
+
+- 列出所有 `topic = generative-models` 的论文
+- 用 `status` 做阅读队列（`unread` → `reading` → `done`）
+- 按 `year` 或 `rating` 排序
+
+### 项目管理
+
+```org
+* Rewrite sync layer #task #project
+```
+
+`#task` / `#project` 这样的标签可以在 schema 中定义字段：`status`, `priority`, `owner`, `project` 等。  
+字段值统一存储在 Org-SuperTag 数据库中，通过表单、表格、看板视图来编辑，而不是手写 `- key: value`。
+
+配合：
+
+- `M-x supertag-view-kanban` 做看板视图
+- 自定义查询实现 “本周高优先级任务” 等过滤
+
+### 会议与日志
+
+```org
+* Sprint Planning 2024-11-15 #meeting
+```
+
+在 `#meeting` 上定义字段：`date`, `participants`, `decisions` 等，  
+对每条会议记录的对应节点填写字段值。之后可以：
+
+- 查询某个时间范围内的所有 `#meeting`
+- 按参与人或项目筛选会议
+
+---
+
+## 查询与视图
+
+底层查询引擎是 Lisp 表达式。低层 API 可以直接调用：
+
+```emacs-lisp
+;; 高优先级项目
+(supertag-search
+ '(and (tag "project")
+       (field "priority" "high")))
+
+;; 未读论文
+(supertag-search
+ '(and (tag "paper")
+       (field "status" "unread")))
+```
+
+在此之上，Org-SuperTag 提供：
+
+- **交互式搜索**：`M-x supertag-search`
+- **视图**：节点表单、表格视图、看板视图等
+- **查询块（query block）**：直接写在 Org 文件中的动态查询块
+
+更多与补全、自动化、捕获系统的联动，参见：
+
+- `doc/COMPLETION-GUIDE.md`
+- `doc/AUTOMATION-SYSTEM-GUIDE.md`
+- `doc/CAPTURE-GUIDE.md`
+
+---
+
+## 常用命令（预览）
+
+这里只列出最常用的入口，完整列表请以 `supertag-ui-*.el` 为准：
+
+| Command                     | 功能说明                                   |
+| --------------------------- | ------------------------------------------ |
+| `M-x supertag-add-tag`     | 给当前节点添加一个内联 `#tag`             |
+| `M-x supertag-view-node`   | 查看/编辑当前节点的结构化字段             |
+| `M-x supertag-search`      | 运行结构化搜索                             |
+| `M-x supertag-capture`     | 使用模板捕获带标签与字段的新节点         |
+| `M-x supertag-view-table`  | 用表格视图展示一组节点                     |
+| `M-x supertag-view-kanban` | 用看板视图展示任务 / 项目                  |
+
+UI 稳定后，这一节应同步维护，以免命令说明与实际实现偏离。
+
+---
+
+## 迁移与兼容性
+
+### 从 Org-SuperTag 4.x 迁移
+
+5.0 使用了完全不同的内部存储引擎，需要一次性迁移。
+
+**在做任何操作之前，请先备份旧的 Org-SuperTag 数据目录。**
+
+1. 找到旧的数据目录（通常在 `~/.emacs.d/org-supertag/`）
+2. 把整个目录拷贝到其他位置（或纳入版本控制）
+3. 在 Emacs 中加载迁移代码：
+
+   ```emacs-lisp
+   M-x load-file RET supertag-migration.el RET
+   ```
+
+4. 运行迁移：
+
+   ```emacs-lisp
+   M-x supertag-migrate-database-to-new-arch RET
+   ```
+
+5. 重启 Emacs
+
+如果迁移失败，或者迁移后的数据看起来不对，你可以：
+
+- 关闭 Emacs
+- 恢复备份的 Org-SuperTag 数据目录
+- 重新打开 Emacs，暂时继续使用旧版本，直到问题解决
+
+### 从纯 Org / 其他工具 迁移
+
+如果你目前使用的是：
+
+- 纯 Org 文件 + 临时标签
+- 其他知识管理工具（Notion、Obsidian、Org-roam 等）
+
+推荐按以下方式**渐进式采用**：
+
+1. 先选择一个领域（例如 `projects` 或 `papers`）
+2. 在相关标题上开始使用内联 `#tag`
+3. 在对应 tag 上定义字段（通过 tag/schema UI），然后通过节点视图为这些节点填值
+4. 之后在日常使用中，顺手把访问到的旧条目转成结构化格式，并用搜索/视图验证结果
+
+整个过程不需要一次性“全量迁移”，可以完全按你自己的节奏推进。
+
+---
+
+## 数据存储与备份
+
+Org-SuperTag 把 Org 文件视为**节点内容和标签的真实来源**。  
+结构化字段值、关系以及视图配置则保存在一个配套的数据库目录中，通常是：
+
+- `~/.emacs.d/org-supertag/`
+
+该目录包含：
+
+- 节点与标签的索引化表示
+- 每个节点的字段值（这些结构化数据并不体现在 Org 文本中）
+- 同步与视图的辅助状态
+- 自动快照 / 备份数据
+
+建议：
+
+- 对 Org 文件和 Org-SuperTag 数据目录都做定期备份
+- 如果用 git 管理 Org 文件，可以考虑只对 Org-SuperTag 目录做“快照式”备份，而不是把全部缓存文件纳入版本控制
+
+如果内部数据库出现损坏，一般可以通过以下步骤恢复：
+
+```emacs-lisp
+M-x supertag-sync-cleanup-database
+M-x supertag-sync-full-initialize
+```
+
+这样会从 Org 文件重新完整扫描并构建数据库。
+
+---
+
+## 故障排查
+
+一些常见的排查入口：
+
+- **数据库看起来不一致 / 损坏**
+
+  ```emacs-lisp
+  M-x supertag-sync-cleanup-database
+  ```
+
+- **想看看数据库里到底存了什么**
+
+  ```emacs-lisp
+  M-x supertag-search
+  ```
+
+- **某个文件的同步有问题**
+
+  ```emacs-lisp
+  M-x supertag-sync-analyze-file
+  ```
+
+更多与自动化相关的调试说明，参见：
+
+- `doc/AUTOMATION-SYSTEM-GUIDE.md`
+- `doc/AUTOMATION-SYSTEM-GUIDE_cn.md`
+
+---
+
+## 与其他工具的关系
+
+极简版对比：
+
+| 工具     | Org-SuperTag 的视角                         |
+| -------- | ------------------------------------------- |
+| Org-roam | Org-roam 更偏图/链接；SuperTag 更偏表和字段 |
+| Obsidian | SuperTag 原生集成于 Emacs & Org            |
+| Notion   | SuperTag 离线、可编程、纯文本               |
+
+Org-SuperTag 不打算“替代一切”，它聚焦在：
+
+- **在纯文本上叠加结构化字段层**
+- **可编程的查询与视图**
+- **完全留在 Emacs / Org 生态之内**
+
+---
+
+## 延伸阅读
+
+如果你想深入理解整个系统，推荐从这些文档继续看起：
+
+- `doc/ABOUT-QUERY-BLOCK.md` / `doc/ABOUT-QUERY-BLOCK_cn.md`
+- `doc/AUTOMATION-SYSTEM-GUIDE.md` / `doc/AUTOMATION-SYSTEM-GUIDE_cn.md`
+- `doc/CAPTURE-GUIDE.md` / `doc/CAPTURE-GUIDE_cn.md`
+- `doc/COMPARE-NEW-OLD-ARCHITECTURE.md` / `doc/COMPARE-NEW-OLD-ARCHITECHTURE_cn.md`
+
+本中文草稿的目标，是作为一个稳定的、面向用户的总览入口，  
+把阅读路径引导到这些更细节的设计与使用文档中。
+
+

--- a/supertag-service-org.el
+++ b/supertag-service-org.el
@@ -9,8 +9,9 @@
   (require 'cl-lib)
   (require 'org)
   (require 'org-id) ;; Required for org-id-goto
-(require 'supertag-core-store)
-(require 'supertag-ops-node)
+  (require 'subr-x)
+  (require 'supertag-core-store)
+  (require 'supertag-ops-node)
   (require 'supertag-services-sync)
   (require 'supertag-ops-tag)
   (require 'supertag-ops-relation)
@@ -66,6 +67,180 @@
         (let ((tag-regexp (concat "\\s-?#" (regexp-quote tag-name) "\\b")))
           (when (re-search-forward tag-regexp (line-end-position) t)
             (replace-match ""))))))
+
+  ;; ---------------------------------------------------------------------------
+  ;; Field export helpers (DB -> Org properties)
+  ;; ---------------------------------------------------------------------------
+
+  (defcustom supertag-export-field-property-prefix "ST_"
+    "Legacy prefix used for Org properties created when exporting fields.
+New exports no longer use this prefix in property names, but the prefix
+is still used to recognize and clean up older exported properties."
+    :type 'string
+    :group 'org-supertag)
+
+  (defcustom supertag-debug-export-fields nil
+    "When non-nil, log detailed information during field export."
+    :type 'boolean
+    :group 'org-supertag)
+
+  (defun supertag-export--sanitize-symbol-component (name)
+    "Return NAME uppercased and sanitized for use in property names."
+    (let* ((s (upcase (format "%s" (or name ""))))
+           (s (replace-regexp-in-string "[^A-Z0-9_]" "_" s)))
+      (if (string-empty-p s) "FIELD" s)))
+
+  (defun supertag-export--field-property-name (_tag-id field-name)
+    "Build human-friendly Org property name for FIELD-NAME.
+TAG-ID is currently ignored; property names are derived only from the
+field name, uppercased and sanitized. For example, \"rate\" becomes
+\"RATE\" and \"who\" becomes \"WHO\"."
+    (supertag-export--sanitize-symbol-component field-name))
+
+  (defun supertag-export--format-date (value)
+    "Best-effort formatting of VALUE as a date string."
+    (cond
+     ((null value) "")
+     ((stringp value) value)
+     ;; Emacs time list (high low micro pico)
+     ((and (listp value) (= (length value) 4))
+      (format-time-string "%Y-%m-%d" value))
+     ;; Fallback
+     (t (format "%s" value))))
+
+  (defun supertag-export--format-timestamp (value)
+    "Best-effort formatting of VALUE as a timestamp string."
+    (cond
+     ((null value) "")
+     ((stringp value) value)
+     ;; Emacs time list (high low micro pico)
+     ((and (listp value) (= (length value) 4))
+      (format-time-string "%Y-%m-%d %H:%M" value))
+     (t (format "%s" value))))
+
+  (defun supertag-export--field-value-to-string (tag-id field-name value)
+    "Convert field VALUE for TAG-ID/FIELD-NAME into a string for properties."
+    (let* ((field-def (ignore-errors (supertag-tag-get-field tag-id field-name)))
+           (type (plist-get field-def :type)))
+      (pcase type
+        (:boolean (if value "true" "false"))
+        (:date (supertag-export--format-date value))
+        (:timestamp (supertag-export--format-timestamp value))
+        ;; For list-like types, serialize as readable Lisp.
+        (:options (prin1-to-string value))
+        (:tag (prin1-to-string value))
+        (:node-reference
+         ;; Resolve node IDs to their titles for human-friendly export.
+         (let* ((ids (cond
+                      ((null value) nil)
+                      ((and (listp value) (not (stringp value))) value)
+                      (t (list value))))
+                (titles
+                 (delq nil
+                       (mapcar
+                        (lambda (id)
+                          (let* ((id-str (format "%s" id))
+                                 (node (supertag-node-get id-str))
+                                 (title (plist-get node :title)))
+                            (or title id-str)))
+                        ids))))
+           (mapconcat #'identity titles ", ")))
+        ;; Default: stringify.
+        (_ (format "%s" (or value ""))))))
+
+  (defun supertag-export--collect-node-field-properties (node-id)
+    "Collect all field values for NODE-ID as an alist of (PROP . STRING)."
+    (let* ((fields-root (supertag-store-get-collection :fields))
+           (node-table (and (hash-table-p fields-root)
+                            (gethash node-id fields-root))))
+      (when (hash-table-p node-table)
+        (let (result)
+          (maphash
+           (lambda (tag-id tag-table)
+             (when (hash-table-p tag-table)
+               (maphash
+                (lambda (field-name value)
+                  (let* ((prop-name (supertag-export--field-property-name tag-id field-name))
+                         (str (supertag-export--field-value-to-string tag-id field-name value)))
+                    (push (cons prop-name str) result)))
+                tag-table)))
+           node-table)
+          result))))
+
+  (defun supertag-export--apply-properties-at-point (props-alist)
+    "Apply PROPS-ALIST as ST_* properties at current heading.
+Returns non-nil when any property was changed."
+    (let* ((existing (org-entry-properties nil 'standard))
+           (prefix supertag-export-field-property-prefix)
+           (wanted-keys (mapcar #'car props-alist))
+           (changed nil))
+      ;; Set or update properties
+      (dolist (pair props-alist)
+        (let* ((key (car pair))
+               (new (or (cdr pair) ""))
+               (old (cdr (assoc key existing))))
+          (unless (string= (or old "") new)
+            (org-entry-put (point) key new)
+            (setq changed t))))
+      ;; Delete obsolete ST_* properties
+      (dolist (pair existing)
+        (let ((key (car pair)))
+          (when (and (string-prefix-p prefix key)
+                     (not (member key wanted-keys)))
+            (org-entry-delete (point) key)
+            (setq changed t))))
+      changed))
+
+  (defun supertag-export-all-fields-to-properties (&optional save-buffers)
+    "Export all field values from the database into Org properties.
+This scans the :fields collection, and for each node with field values,
+adds or updates Org properties on its heading using the prefix
+`supertag-export-field-property-prefix'. When SAVE-BUFFERS is non-nil
+(or when called interactively with a prefix argument), modified buffers
+are saved automatically."
+    (interactive "P")
+    (let* ((fields-root (supertag-store-get-collection :fields))
+           (node-ids (when (hash-table-p fields-root)
+                       (let (ids)
+                         (maphash (lambda (id _value)
+                                    (push id ids))
+                                  fields-root)
+                         (nreverse ids)))))
+      (cond
+       ((not (hash-table-p fields-root))
+        (message "Supertag export: :fields collection is not initialized."))
+       ((null node-ids)
+        (message "Supertag export: no nodes with field values found."))
+       (t
+        (let* ((total (length node-ids))
+               (reporter (make-progress-reporter
+                          "Supertag: exporting fields to Org properties..."
+                          0 total))
+               (modified-files (make-hash-table :test 'equal))
+               (index 0))
+          (dolist (node-id node-ids)
+            (cl-incf index)
+            (let ((props (supertag-export--collect-node-field-properties node-id)))
+              (when props
+                (supertag-service-org--with-node-buffer
+                 node-id
+                 (lambda ()
+                   (when (org-at-heading-p)
+                     (let ((changed (supertag-export--apply-properties-at-point props)))
+                       (when changed
+                         (let ((file (buffer-file-name)))
+                           (when file
+                             (puthash file t modified-files)
+                             (when save-buffers
+                               (save-buffer)
+                               (supertag--mark-internal-modification file)))))))))))
+            (progress-reporter-update reporter index))
+          (progress-reporter-done reporter)
+          (let ((file-count (hash-table-count modified-files)))
+            (message "Supertag export: processed %d nodes, modified %d files%s."
+                     total
+                     file-count
+                     (if save-buffers ", saved buffers" ""))))))))
 
   (provide 'supertag-service-org)
   ;;; supertag-service-org.el ends here


### PR DESCRIPTION

## Features

### Field Export to Org Properties with Progress UI

- Added `supertag-export-all-fields-to-properties` command to export all database field values to Org `:PROPERTIES:` drawers for nodes that have fields.
- Field names are exported as human-friendly Org property keys (e.g. `rate` → `:RATE:`, `who` → `:WHO:`) while keeping the database as the single source of truth.
- Node-reference fields are exported as readable titles (e.g. director names) instead of raw node IDs, improving interoperability with external tools that only see Org files.
- The export process shows a minibuffer progress bar and a final summary message, and can optionally save modified buffers when called with a prefix argument.
