### PR TITLE
fix: avoid reserved symbol 't' as lambda parameter in tag lambdas

### DIFF
--- a/supertag-services-capture.el
+++ b/supertag-services-capture.el
@@ -651,7 +651,7 @@ capture DSL."
                                (replace-regexp-in-string
                                 "\\(?:^\\|\\s-\\)#[^[:space:]#]+" "" title)))
                              (tag-string
-                              (mapconcat (lambda (t) (concat "#" t))
+                              (mapconcat (lambda (tag) (concat "#" tag))
                                          unique-tags " "))
                              (new-title
                               (string-trim

--- a/supertag-ui-completion.el
+++ b/supertag-ui-completion.el
@@ -410,7 +410,7 @@ RET creates and records the tag immediately."
          (node-id (org-id-get-create))
          (current (when node-id (supertag-completion--get-node-tags node-id)))
          (available (if current
-                        (seq-remove (lambda (t) (member t current)) all)
+                        (seq-remove (lambda (tag) (member tag current)) all)
                       all))
          (input (completing-read "Tag (RET on a typed name creates it): "
                                  available nil nil)))


### PR DESCRIPTION
## What

Rename the reserved symbol `t` used as a lambda parameter in two tag-handling lambdas.

## Why

Both call sites bound `t` as a lambda variable:

- `supertag-services-capture.el` — building the reconstructed `#tag` string
- `supertag-ui-completion.el` — filtering out already-applied tags

`t` is a constant symbol in Emacs Lisp and cannot be used as a variable. Byte-compilation rejects it outright:

```
$ emacs -Q --batch --eval '(byte-compile (lambda (t) (concat "#" t)))'
Error: Invalid lambda variable t
```

Under lexical binding these lambdas would also error at runtime when invoked. Renaming `t` to `tag` fixes both.

## Change

Two-line, mechanical rename; no behavior change beyond making the code loadable/callable.

## Verification

- Repro above confirms the pre-fix byte-compile failure.
- `rg '\(lambda \(t[ )]'` across the tree → 0 remaining instances.
