### PR TITLE
fix: allow independently compiled persistence

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,6 +21,9 @@
   preserve existing behavior.
 
 ** Fixes
+*** Package loading
+- Independently byte-compiled persistence code no longer raises =invalid-function supertag-config-guard--with-allow= while loading Org-SuperTag.
+
 *** Reference insertion cursor position
 - =supertag-add-reference= now saves the cursor as an Emacs marker
   instead of a raw integer position. This ensures the forward link is

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,9 +21,6 @@
   preserve existing behavior.
 
 ** Fixes
-*** Package loading
-- Independently byte-compiled persistence code no longer raises =invalid-function supertag-config-guard--with-allow= while loading Org-SuperTag.
-
 *** Reference insertion cursor position
 - =supertag-add-reference= now saves the cursor as an Emacs marker
   instead of a raw integer position. This ensures the forward link is

--- a/supertag-core-persistence.el
+++ b/supertag-core-persistence.el
@@ -20,6 +20,9 @@
   "Directory for storing Org-Supertag data.
 This is a fallback definition. The primary definition is in org-supertag.el.")
 
+(defvar supertag--config-guard-allow nil
+  "Non-nil while guarded persistence configuration changes are allowed.")
+
 (defun supertag-data-file (filename)
   "Get full path for data file.
 FILENAME is relative to `supertag-data-directory`."
@@ -230,9 +233,7 @@ or files with a `.db` extension that still contain an Emacs-lisp printed store."
 (defun supertag--persistence--set-db-file (path)
   "Set `supertag-db-file` to PATH, respecting config guard when available."
   (when (and (stringp path) (> (length path) 0))
-    (if (fboundp 'supertag-config-guard--with-allow)
-        (supertag-config-guard--with-allow
-          (setq supertag-db-file path))
+    (let ((supertag--config-guard-allow t))
       (setq supertag-db-file path))))
 
 (defun supertag--persistence--try-read-store (path)

--- a/supertag-persistence-test.el
+++ b/supertag-persistence-test.el
@@ -99,6 +99,40 @@
              (node (gethash id loaded-nodes)))
         (should (equal (plist-get node :id) id))))))
 
+(ert-deftest supertag-persistence-set-db-file-compiles-without-config-guard ()
+  "The persistence module must compile independently of the config guard macro."
+  (let* ((source-directory
+          (file-name-directory
+           (symbol-file 'supertag-persistence-test--make-store-with-nodes 'defun)))
+         (source-file (expand-file-name "supertag-core-persistence.el"
+                                        source-directory))
+         (definition
+          (with-temp-buffer
+            (insert-file-contents source-file)
+            (re-search-forward
+             "^(defun supertag--persistence--set-db-file\\_>")
+            (goto-char (match-beginning 0))
+            (read (current-buffer))))
+         (had-macro (fboundp 'supertag-config-guard--with-allow))
+         (saved-macro (and had-macro
+                           (symbol-function 'supertag-config-guard--with-allow)))
+         compiled-setter)
+    (unwind-protect
+        (progn
+          (when had-macro
+            (fmakunbound 'supertag-config-guard--with-allow))
+          (let ((byte-compile-warnings nil))
+            (setq compiled-setter
+                  (byte-compile (cons 'lambda (cddr definition)))))
+          (fset 'supertag-config-guard--with-allow
+                (cons 'macro (lambda (&rest body) (cons 'progn body))))
+          (let ((supertag-db-file nil))
+            (funcall compiled-setter "/tmp/supertag-regression.db")
+            (should (equal supertag-db-file "/tmp/supertag-regression.db"))))
+      (if had-macro
+          (fset 'supertag-config-guard--with-allow saved-macro)
+        (fmakunbound 'supertag-config-guard--with-allow)))))
+
 (provide 'supertag-persistence-test)
 
 ;;; supertag-persistence-test.el ends here


### PR DESCRIPTION
## Summary

- make the persistence DB-file setter safe when its module is compiled independently
- preserve dynamic config-guard behavior without a cross-file macro dependency
- add a regression test for the compile-time-absent/runtime-macro-present failure mode

## Root cause

`supertag-core-persistence.el` guarded a macro invocation with a runtime `fboundp` check. When that file was byte-compiled before the macro definition was available, Emacs emitted a runtime function call. Installed package loading then found a macro object where a function was expected and raised `invalid-function supertag-config-guard--with-allow`.

## Verification

- regression test failed with the reported `invalid-function` before the fix and passes afterward
- independent byte-compilation succeeds
- batch loading `org-supertag` succeeds
- config-guard watcher observes and records the allowed DB-file update

The broader persistence test file currently has one unrelated failing failover assertion (`supertag-persistence-load-store-failover-keeps-working`); the other three tests pass.
