### PR TITLE
refactor: keep config guard ownership in the entrypoint

### DIFF
--- a/supertag-core-persistence.el
+++ b/supertag-core-persistence.el
@@ -20,8 +20,7 @@
   "Directory for storing Org-Supertag data.
 This is a fallback definition. The primary definition is in org-supertag.el.")
 
-(defvar supertag--config-guard-allow nil
-  "Non-nil while guarded persistence configuration changes are allowed.")
+(defvar supertag--config-guard-allow)
 
 (defun supertag-data-file (filename)
   "Get full path for data file.


### PR DESCRIPTION
## Summary

- keep the canonical config-guard initialization and documentation in `org-supertag.el`
- leave only a bare `defvar` declaration in persistence so independent compilation still preserves dynamic binding
- avoid `eval-when-compile`, which would not cover interpreted loading

## Related

Follow-up to #177.

## Verification

- independent byte-compilation of `supertag-core-persistence.el`
- `supertag-persistence-set-db-file-compiles-without-config-guard` passes
- compiled persistence + enabled watcher updates both DB path and guard state
- stable ERT suite: 32/32 passed
- `git diff --check`

## Risk / rollback

Narrow declaration-only cleanup. Revert the single commit to restore the duplicate initialization/documentation.