### PR TITLE
fix: deduplicate Refs table column

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,6 +21,9 @@
   preserve existing behavior.
 
 ** Fixes
+*** Table view
+- Suppress schema fields whose slug is =refs= so the reserved Refs column is not displayed twice.
+
 *** Reference insertion cursor position
 - =supertag-add-reference= now saves the cursor as an Emacs marker
   instead of a raw integer position. This ensures the forward link is

--- a/supertag-view-table.el
+++ b/supertag-view-table.el
@@ -533,7 +533,7 @@ Automatically detects virtual databases and uses their database fields."
                                   (and slug (equal slug supertag-view-table--refs-field-id))
                                   (gethash dedupe-key seen))
                        do (puthash dedupe-key t seen)
-                       collect (let ((col `(:name ,raw-name
+                       and collect (let ((col `(:name ,raw-name
                                           :key ,(intern (or slug raw-name))
                                           :field-id ,slug
                                           :width 20)))

--- a/test-view-table.el
+++ b/test-view-table.el
@@ -1,0 +1,26 @@
+;;; test-view-table.el --- Tests for table views -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'supertag-view-table)
+
+(ert-deftest supertag-view-table-refs-field-is-not-duplicated ()
+  "The reserved Refs column must replace a same-slug schema field."
+  (let ((supertag-use-global-fields nil))
+    (cl-letf (((symbol-function 'supertag-tag-get-id-by-name)
+               (lambda (_) "task"))
+              ((symbol-function 'supertag-view-table--ensure-refs-field)
+               #'ignore)
+              ((symbol-function 'supertag-tag-get-all-fields)
+               (lambda (_) '((:name "Refs" :type :node-reference))))
+              ((symbol-function 'supertag-view-table--get-virtual-columns)
+               #'ignore))
+      (let ((keys
+             (mapcar (lambda (column) (plist-get column :key))
+                     (supertag-view-table--get-columns-for-tag "task"))))
+        (should (= 1 (cl-count :refs keys :test #'eq)))
+        (should-not (memq 'refs keys))))))
+
+(provide 'test-view-table)
+
+;;; test-view-table.el ends here


### PR DESCRIPTION
## Summary

- keep the reserved Refs table column from being duplicated by a same-slug schema field
- ensure the cl-loop guard also governs field collection
- add focused ERT regression coverage and an Unreleased changelog entry

## Tests

- `emacs --batch -l /Users/ken/.emacs.d/early-init.el -L . -l test-view-table.el -f ert-run-tests-batch-and-exit`
