### PR TITLE
fix: respect theme for table parent headings

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -22,6 +22,7 @@
 
 ** Fixes
 *** Table view
+- Parent headings now inherit theme-appropriate subdued styling instead of using a hard-coded dark background.
 - Suppress schema fields whose slug is =refs= so the reserved Refs column is not displayed twice.
 
 *** Reference insertion cursor position

--- a/supertag-view-table.el
+++ b/supertag-view-table.el
@@ -31,7 +31,7 @@
 ;;; Faces
 
 (defface supertag-view-table-parent-title-face
-  '((t :inherit shadow :background "#303030"))
+  '((t :inherit shadow))
   "Face used for the parent-title line in the Title column."
   :group 'supertag-view)
 
@@ -877,7 +877,7 @@ Uses improved styling from old version."
                                            (nth (- (length olp) 2) olp))))
                     (if (and parent-title (not (string-empty-p parent-title)))
                         ;; First line: current title (with org links rendered);
-                        ;; second line: parent title (grey background).
+                        ;; second line: parent title (subdued).
                         (concat rendered-title "\n"
                                 (propertize parent-title 'face 'supertag-view-table-parent-title-face))
                       rendered-title)))


### PR DESCRIPTION
## Summary

- remove the hard-coded dark background from table parent headings
- retain the named semantic face and inherit theme-appropriate `shadow` styling
- document the user-visible fix in the changelog

## Verification

- configured Emacs in-memory byte compilation completed successfully
- active face inspection reports `:inherit shadow` and `:background unspecified`
- standards and spec reviews reported no findings
